### PR TITLE
Fix tsconfig module resolution for npm build

### DIFF
--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "module": "commonjs",
+    "moduleResolution": "node",
     "declaration": true,
     "removeComments": true,
     "emitDecoratorMetadata": true,


### PR DESCRIPTION
## Summary
- ensure Node-style module resolution for backend TypeScript compiler

## Testing
- `npm run build`
- `npm run master-switch` (manually stopped with SIGINT)
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683a0a7eb82c832ea815b64099ace9ec