### PR TITLE
Fix realtor API path

### DIFF
--- a/backend/src/leads/leads.controller.ts
+++ b/backend/src/leads/leads.controller.ts
@@ -10,11 +10,11 @@ import {
 } from '@nestjs/common';
 import { LeadsService } from './leads.service';
 
-@Controller('leads')
+@Controller()
 export class LeadsController {
   constructor(private readonly leads: LeadsService) {}
 
-  @Post()
+  @Post('leads')
   @HttpCode(201)
   async create(
     @Body('name') name: string,


### PR DESCRIPTION
## Summary
- correct leads controller base path so `/api/realtor` resolves

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683de00a0ab0832eadfd0ed89dc7c09c