### PR TITLE
Adjust calendar location

### DIFF
--- a/frontend/site/src/App.jsx
+++ b/frontend/site/src/App.jsx
@@ -73,6 +73,20 @@ export default function App() {
         <div className="skip-text">
           OR Skip the line and schedule a call with me NOW
         </div>
+        <div className="calendar-section">
+          <AppointmentCalendar
+            realtorId={realtor.realtorId}
+            onSelect={(sel) =>
+              setSelection({ ...sel, realtorId: realtor.realtorId })
+            }
+          />
+          <BookingForm
+            details={selection}
+            realtorUuid={realtorUuid}
+            onBooked={() => setSelection(null)}
+            user={user}
+          />
+        </div>
         <div className="buttons">
           <button
             className="btn btn-testimonials"
@@ -91,21 +105,6 @@ export default function App() {
             </a>
           )}
         </div>
-      </div>
-
-      <div className="calendar-section">
-        <AppointmentCalendar
-          realtorId={realtor.realtorId}
-          onSelect={(sel) =>
-            setSelection({ ...sel, realtorId: realtor.realtorId })
-          }
-        />
-        <BookingForm
-          details={selection}
-          realtorUuid={realtorUuid}
-          onBooked={() => setSelection(null)}
-          user={user}
-        />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- place the appointment calendar directly under the skip-text notice
- show customer testimonials and website link after the calendar

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683f00071990832e9285e168a1b949ea