### PR TITLE
Improve video scaling on mobile

### DIFF
--- a/backend/src/leads/leads.service.ts
+++ b/backend/src/leads/leads.service.ts
@@ -52,10 +52,15 @@ export class LeadsService {
       .order('created_at', { ascending: false })
       .limit(1)
       .maybeSingle();
-    if (!data) return null;
+    const lead = data as {
+      first_name: string;
+      last_name: string;
+      phone: string;
+    } | null;
+    if (!lead) return null;
     return {
-      full_name: `${data.first_name} ${data.last_name}`.trim(),
-      phone: data.phone,
+      full_name: `${lead.first_name} ${lead.last_name}`.trim(),
+      phone: lead.phone,
     };
   }
 
@@ -70,16 +75,23 @@ export class LeadsService {
       console.error('[LeadsService] Supabase error', error);
       throw error;
     }
-    if (!data) {
+    const realtor = data as {
+      realtor_id: number;
+      f_name: string;
+      e_name: string;
+      video_url: string;
+      website_url: string;
+    } | null;
+    if (!realtor) {
       console.debug('[LeadsService] no realtor found for', uuid);
       return null;
     }
-    console.debug('[LeadsService] found realtor id', data.realtor_id);
+    console.debug('[LeadsService] found realtor id', realtor.realtor_id);
     return {
-      realtorId: data.realtor_id,
-      name: `${data.f_name} ${data.e_name}`.trim(),
-      video_url: data.video_url,
-      website_url: data.website_url,
+      realtorId: realtor.realtor_id,
+      name: `${realtor.f_name} ${realtor.e_name}`.trim(),
+      video_url: realtor.video_url,
+      website_url: realtor.website_url,
     };
   }
 }

--- a/frontend/site/src/App.css
+++ b/frontend/site/src/App.css
@@ -47,13 +47,18 @@ body {
  and does not take over the whole page when it loads.
 */
 .video {
+  position: relative;
   width: 100%;
+  padding-top: 56.25%; /* 16:9 ratio */
+  overflow: hidden;
 }
 
 .video iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
   width: 100% !important;
-  height: auto !important;
-  aspect-ratio: 16 / 9;
+  height: 100% !important;
   display: block;
   border: none;
 }

--- a/frontend/site/src/components/VideoPlayer.jsx
+++ b/frontend/site/src/components/VideoPlayer.jsx
@@ -16,6 +16,8 @@ export default function VideoPlayer({ html }) {
     const iframe = doc.querySelector('iframe');
     if (iframe) {
       iframe.removeAttribute('style');
+      iframe.removeAttribute('width');
+      iframe.removeAttribute('height');
       sanitized = iframe.outerHTML;
     }
   } catch (err) {


### PR DESCRIPTION
## Summary
- sanitize width and height attributes when rendering realtor video iframe
- make video container responsive using a 16:9 padding wrapper
- add explicit typings when loading leads and realtors

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683f0e5b7014832e841709cbc0ec4046