### PR TITLE
Fix video player fallback for browsers without DOMParser

### DIFF
--- a/frontend/site/src/components/VideoPlayer.jsx
+++ b/frontend/site/src/components/VideoPlayer.jsx
@@ -11,14 +11,22 @@ export default function VideoPlayer({ html }) {
 
   let sanitized = html;
   try {
-    const parser = new DOMParser();
-    const doc = parser.parseFromString(html, 'text/html');
-    const iframe = doc.querySelector('iframe');
-    if (iframe) {
-      iframe.removeAttribute('style');
-      iframe.removeAttribute('width');
-      iframe.removeAttribute('height');
-      sanitized = iframe.outerHTML;
+    if (typeof window !== 'undefined' && typeof DOMParser !== 'undefined') {
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(html, 'text/html');
+      const iframe = doc.querySelector('iframe');
+      if (iframe) {
+        iframe.removeAttribute('style');
+        iframe.removeAttribute('width');
+        iframe.removeAttribute('height');
+        sanitized = iframe.outerHTML;
+      }
+    } else {
+      // Fallback for environments without DOMParser
+      sanitized = html
+        .replace(/style="[^"]*"/g, '')
+        .replace(/\swidth="[^"]*"/g, '')
+        .replace(/\sheight="[^"]*"/g, '');
     }
   } catch (err) {
     console.error('Failed to sanitize video HTML', err);


### PR DESCRIPTION
## Summary
- improve VideoPlayer sanitation fallback when DOMParser is unavailable

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_683f12bb05b4832ea7f928fd2502444e