### PR TITLE
Swap phone/email order and make phone required

### DIFF
--- a/frontend/survey/dynamic_survey.html
+++ b/frontend/survey/dynamic_survey.html
@@ -562,19 +562,19 @@
                         <input type="text" name="fullName" required placeholder="Enter your full name">
                     </div>
                     <div class="contact-field">
-                        <label>Email Address <span class="required">*</span></label>
-                        <input type="text" name="email" required placeholder="your.email@example.com">
+                        <label>Phone Number <span class="required">*</span></label>
+                        <input type="text" name="phone" required placeholder="(555) 123-4567">
                     </div>
                     <div class="contact-field">
-                        <label>Phone Number (optional)</label>
-                        <input type="text" name="phone" placeholder="(555) 123-4567">
+                        <label>Email Address (optional)</label>
+                        <input type="text" name="email" placeholder="your.email@example.com">
                     </div>
                 </div>
             </div>
 
             <div class="navigation-buttons">
-                <button type="button" class="nav-btn prev-btn" id="prevBtn" disabled>Previous</button>
                 <button type="button" class="nav-btn next-btn" id="nextBtn">Next</button>
+                <button type="button" class="nav-btn prev-btn" id="prevBtn" disabled>Previous</button>
                 <button type="submit" class="nav-btn submit-btn" id="submitBtn" style="display: none;">Get My Free Estimate</button>
             </div>
 

--- a/frontend/survey/src/markup.html
+++ b/frontend/survey/src/markup.html
@@ -263,19 +263,19 @@
                         <input type="text" name="fullName" required placeholder="Enter your full name">
                     </div>
                     <div class="contact-field">
-                        <label>Email Address <span class="required">*</span></label>
-                        <input type="text" name="email" required placeholder="your.email@example.com">
+                        <label>Phone Number <span class="required">*</span></label>
+                        <input type="text" name="phone" required placeholder="(555) 123-4567">
                     </div>
                     <div class="contact-field">
-                        <label>Phone Number (optional)</label>
-                        <input type="text" name="phone" placeholder="(555) 123-4567">
+                        <label>Email Address (optional)</label>
+                        <input type="text" name="email" placeholder="your.email@example.com">
                     </div>
                 </div>
             </div>
 
             <div class="navigation-buttons">
-                <button type="button" class="nav-btn prev-btn" id="prevBtn" disabled>Previous</button>
                 <button type="button" class="nav-btn next-btn" id="nextBtn">Next</button>
+                <button type="button" class="nav-btn prev-btn" id="prevBtn" disabled>Previous</button>
                 <button type="submit" class="nav-btn submit-btn" id="submitBtn" style="display: none;">Get My Free Estimate</button>
             </div>
 

--- a/frontend/survey/src/markup.js
+++ b/frontend/survey/src/markup.js
@@ -264,19 +264,19 @@ export const surveyMarkup = `
                         <input type="text" name="fullName" required placeholder="Enter your full name">
                     </div>
                     <div class="contact-field">
-                        <label>Email Address <span class="required">*</span></label>
-                        <input type="text" name="email" required placeholder="your.email@example.com">
+                        <label>Phone Number <span class="required">*</span></label>
+                        <input type="text" name="phone" required placeholder="(555) 123-4567">
                     </div>
                     <div class="contact-field">
-                        <label>Phone Number (optional)</label>
-                        <input type="text" name="phone" placeholder="(555) 123-4567">
+                        <label>Email Address (optional)</label>
+                        <input type="text" name="email" placeholder="your.email@example.com">
                     </div>
                 </div>
             </div>
 
             <div class="navigation-buttons">
-                <button type="button" class="nav-btn prev-btn" id="prevBtn" disabled>Previous</button>
                 <button type="button" class="nav-btn next-btn" id="nextBtn">Next</button>
+                <button type="button" class="nav-btn prev-btn" id="prevBtn" disabled>Previous</button>
                 <button type="submit" class="nav-btn submit-btn" id="submitBtn" style="display: none;">Get My Free Estimate</button>
             </div>
 


### PR DESCRIPTION
## Summary
- make phone number mandatory and email optional in the survey contact fields
- show phone field before the email field
- switch Next and Previous button ordering

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f2af35790832e9949744cb9259c99