### PR TITLE
Fix calendar date selection bug

### DIFF
--- a/frontend/site/src/App.css
+++ b/frontend/site/src/App.css
@@ -269,6 +269,13 @@ body {
 
 .calendar-day.other-month {
   color: #555;
+  cursor: default;
+  pointer-events: none;
+}
+
+.calendar-day.other-month:hover {
+  background: none;
+  transform: none;
 }
 
 .calendar-day.today {

--- a/frontend/site/src/components/Callender.jsx
+++ b/frontend/site/src/components/Callender.jsx
@@ -97,7 +97,7 @@ export default function Callender({ realtorId, onSelect }) {
           key={idx}
           className={`calendar-day${c.other ? ' other-month' : ''}$
             {isToday ? ' today' : ''}${selected ? ' selected' : ''}`}
-          onClick={() => selectDate(c.year, c.month, c.day)}
+          onClick={!c.other ? () => selectDate(c.year, c.month, c.day) : undefined}
         >
           {c.day}
         </div>


### PR DESCRIPTION
## Summary
- disable selecting dates from adjacent months
- style days from other months to appear disabled

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f2b65f914832eae29c9580d78a2a7