### PR TITLE
Connect survey and microservice flow

### DIFF
--- a/backend/src/agentHelp/prompt.service.ts
+++ b/backend/src/agentHelp/prompt.service.ts
@@ -7,7 +7,10 @@ type ChatCompletionTool = NonNullable<
 
 @Injectable()
 export class PromptService {
-  systemMessage(): string {
+  systemMessage(followUp = false): string {
+    if (followUp) {
+      return `You are following up with a lead via SMS. Be concise and provide booking assistance.`;
+    }
     return `be helpful, concise, and accurate.`;
   }
 
@@ -16,7 +19,12 @@ export class PromptService {
   }
 
   tools(): ChatCompletionTool[] {
-    return [this.search_web_tool()];
+    return [
+      this.search_web_tool(),
+      this.book_time_tool(),
+      this.list_available_tool(),
+      this.stop_messages_tool(),
+    ];
   }
 
   /* ----------  WEB SEARCH  ---------- */
@@ -35,6 +43,68 @@ export class PromptService {
             },
           },
           required: ['query'],
+        },
+      },
+    };
+  }
+
+  book_time_tool(): ChatCompletionTool {
+    return {
+      type: 'function',
+      function: {
+        name: 'book_time',
+        description: 'Book a meeting time for the lead.',
+        parameters: {
+          type: 'object',
+          properties: {
+            phone: { type: 'string' },
+            full_name: { type: 'string' },
+            booked_date: { type: 'string', description: 'YYYY-MM-DD' },
+            booked_time: { type: 'string', description: 'HH:mm' },
+            time_zone: { type: 'string' },
+            realtor_id: { type: 'number' },
+          },
+          required: [
+            'phone',
+            'full_name',
+            'booked_date',
+            'booked_time',
+            'time_zone',
+            'realtor_id',
+          ],
+        },
+      },
+    };
+  }
+
+  list_available_tool(): ChatCompletionTool {
+    return {
+      type: 'function',
+      function: {
+        name: 'list_available_times',
+        description: 'List available booking times for a date.',
+        parameters: {
+          type: 'object',
+          properties: {
+            realtor_id: { type: 'number' },
+            date: { type: 'string', description: 'YYYY-MM-DD' },
+          },
+          required: ['realtor_id', 'date'],
+        },
+      },
+    };
+  }
+
+  stop_messages_tool(): ChatCompletionTool {
+    return {
+      type: 'function',
+      function: {
+        name: 'stop_messages',
+        description: 'Cancel any scheduled follow-up messages.',
+        parameters: {
+          type: 'object',
+          properties: { phone: { type: 'string' } },
+          required: ['phone'],
         },
       },
     };

--- a/backend/src/agentLogic/agent.controller.ts
+++ b/backend/src/agentLogic/agent.controller.ts
@@ -7,8 +7,17 @@ export class AgentController {
 
   @Post()
   @HttpCode(200)
-  async send(@Body('phone') phone: string, @Body('message') message: string) {
-    const assistant = await this.messageService.send(phone, message);
+  async send(
+    @Body('phone') phone: string,
+    @Body('message') message: string,
+    @Body('followUp') followUp = false,
+  ) {
+    const assistant = await this.messageService.send(
+      phone,
+      message,
+      'gpt-4o-mini',
+      followUp,
+    );
     return { assistant };
   }
 }

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -22,7 +22,6 @@ import { MessengerService } from './messenger/messenger.service';
 import { BookingService } from './booking/booking.service';
 import { BookingController } from './booking/booking.controller';
 
-
 import { OpenAiService } from './agentHelp/openai.service';
 import { PromptService } from './agentHelp/prompt.service';
 

--- a/backend/src/scheduler/cron.ts
+++ b/backend/src/scheduler/cron.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access */
 import { createClient } from '@supabase/supabase-js';
 import { Twilio } from 'twilio';
 
@@ -26,7 +26,7 @@ export async function handler(): Promise<void> {
     return;
   }
 
-  for (const row of (data ?? []) as any[]) {
+  for (const row of data ?? []) {
     try {
       await twilio.messages.create({
         body: row.message_text ?? '',

--- a/frontend/site/src/components/BookingForm.jsx
+++ b/frontend/site/src/components/BookingForm.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 
 export default function BookingForm({ details, realtorUuid, onBooked, user }) {
   const [form, setForm] = useState({
@@ -7,6 +7,14 @@ export default function BookingForm({ details, realtorUuid, onBooked, user }) {
     email: '',
   });
   const [status, setStatus] = useState('');
+
+  useEffect(() => {
+    setForm({
+      name: user?.full_name || '',
+      phone: user?.phone || '',
+      email: '',
+    });
+  }, [user]);
 
   const handle = (e) => {
     setForm({ ...form, [e.target.name]: e.target.value });

--- a/frontend/survey/src/App.jsx
+++ b/frontend/survey/src/App.jsx
@@ -71,7 +71,8 @@ export default function App() {
         q.classList.add('hidden');
       });
 
-      const questionId = stepNumber === 'contact' ? 'contactInfo' : `q${stepNumber}`;
+      const questionId =
+        stepNumber === 'contact' ? 'contactInfo' : `q${stepNumber}`;
       const currentQuestion = document.getElementById(questionId);
       if (currentQuestion) {
         currentQuestion.classList.remove('hidden');
@@ -96,11 +97,14 @@ export default function App() {
     }
 
     function getCurrentStepValue() {
-      const currentQuestionId = currentStep === 'contact' ? 'contactInfo' : `q${currentStep}`;
+      const currentQuestionId =
+        currentStep === 'contact' ? 'contactInfo' : `q${currentStep}`;
       const currentQuestion = document.getElementById(currentQuestionId);
       if (!currentQuestion) return null;
 
-      const radioInput = currentQuestion.querySelector('input[type="radio"]:checked');
+      const radioInput = currentQuestion.querySelector(
+        'input[type="radio"]:checked',
+      );
       if (radioInput) return radioInput.value;
 
       const textInput = currentQuestion.querySelector('input[type="text"]');
@@ -110,21 +114,29 @@ export default function App() {
     }
 
     function canProceed() {
-      const currentQuestionId = currentStep === 'contact' ? 'contactInfo' : `q${currentStep}`;
+      const currentQuestionId =
+        currentStep === 'contact' ? 'contactInfo' : `q${currentStep}`;
       const currentQuestion = document.getElementById(currentQuestionId);
       if (!currentQuestion) return false;
 
       if (currentQuestionId === 'contactInfo') {
-        const requiredFields = currentQuestion.querySelectorAll('input[required]');
-        return Array.from(requiredFields).every((field) => field.value.trim() !== '');
+        const requiredFields =
+          currentQuestion.querySelectorAll('input[required]');
+        return Array.from(requiredFields).every(
+          (field) => field.value.trim() !== '',
+        );
       }
 
-      const radioChecked = currentQuestion.querySelector('input[type="radio"]:checked');
+      const radioChecked = currentQuestion.querySelector(
+        'input[type="radio"]:checked',
+      );
       if (currentQuestion.querySelector('input[type="radio"]')) {
         return radioChecked !== null;
       }
 
-      const textInput = currentQuestion.querySelector('input[type="text"][required]');
+      const textInput = currentQuestion.querySelector(
+        'input[type="text"][required]',
+      );
       if (textInput) {
         return textInput.value.trim() !== '';
       }
@@ -224,10 +236,28 @@ export default function App() {
         console.error('Failed to create lead', err);
       }
 
-      window.location.href =
-        `${process.env.SITE_URL}/${realtorUuid}/${encodeURIComponent(
-          phone
-        )}`;
+      if (shouldRedirectToRealtor) {
+        window.location.href = `${process.env.SITE_URL}/${realtorUuid}/${encodeURIComponent(phone)}`;
+      } else {
+        document.getElementById('successMessage').textContent =
+          'Thank you! A realtor will contact you soon.';
+        document.getElementById('successMessage').style.display = 'block';
+        await fetch('/api/schedule', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            time: new Date().toISOString(),
+            phone,
+            content:
+              'Thanks for reaching out! A realtor will contact you soon.',
+          }),
+        });
+        await fetch('/api/message', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ phone, message: 'New lead', followUp: true }),
+        });
+      }
     });
 
     showQuestion(1);


### PR DESCRIPTION
## Summary
- wire up new tools for booking, availability, and stop commands
- send AI replies via Twilio
- use follow‑up prompt when survey doesn't redirect
- auto-fill booking form from URL
- schedule reminder SMS if no booking

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6841953cd7b4832ebb5aaa7f42cd7b84