### PR TITLE
Add scheduled_messages table and update Booked schema

### DIFF
--- a/database/postgres.sql
+++ b/database/postgres.sql
@@ -2,9 +2,10 @@
 -- drop any old objects that get in the way
 --    (tables first, then ENUMs; CASCADE blows away dependents)
 -- ─────────────────────────────────────────────────────────────
+drop table if exists public.scheduled_messages cascade;
 drop table if exists public.booked    cascade;
 drop table if exists public.leads     cascade;
-drop table if exists public.realtor  cascade;
+drop table if exists public.realtor   cascade;
 
 
 
@@ -53,13 +54,24 @@ create table public.leads (
 
 /* 2-c  Booked calls / appointments */
 create table public.booked (
-    phone        varchar(50) primary key references public.leads(phone) on delete cascade,
-    name    varchar(255) not null,
-    booked_date  date,
-    booked_time  time,
-    time_zone    varchar(100),
-    realtor_id   bigint not null references public.realtor(realtor_id) on delete cascade,
-    created_at   timestamptz default now()
+    phone           varchar(50) primary key references public.leads(phone) on delete cascade,
+    name            varchar(255) not null,
+    appointment_time timestamptz,
+    meeting_link    varchar(600),
+    realtor_id      bigint not null references public.realtor(realtor_id) on delete cascade,
+    created_at      timestamptz default now()
+);
+
+/* 2-d Scheduled messages for future SMS */
+create table public.scheduled_messages (
+    id             bigserial primary key,
+    phone          varchar(50) not null references public.leads(phone) on delete cascade,
+    realtor_id     bigint not null references public.realtor(realtor_id) on delete cascade,
+    scheduled_time timestamptz not null,
+    message_type   varchar(20) default 'text',
+    message_status varchar(20) default 'pending',
+    message_text   text,
+    created_at     timestamptz default now()
 );
 
 -- ─────────────────────────────────────────────────────────────

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -1,7 +1,7 @@
 # Database Schema
 
 This document summarizes the main tables used by the Lead Management System.
-The table definitions can be found in [`database/schema.sql`](../database/schema.sql).
+The table definitions can be found in [`database/postgres.sql`](../database/postgres.sql).
 Example data for local development is provided in [`database/seed.sql`](../database/seed.sql).
 
 ## Tables
@@ -39,9 +39,8 @@ Example data for local development is provided in [`database/seed.sql`](../datab
 ### Booked
 - `phone` – primary key
 - `full_name`
-- `booked_date`
-- `booked_time`
-- `time_zone`
+- `appointment_time`
+- `meeting_link`
 - `realtor_id` – references `Realtor`
 - `created_at`
 
@@ -51,7 +50,8 @@ Example data for local development is provided in [`database/seed.sql`](../datab
 
 ### scheduled_messages
 - `id` – primary key
-- `phone`
+- `phone` – references `Leads`
+- `realtor_id` – references `Realtor`
 - `scheduled_time`
 - `message_type`
 - `message_status`
@@ -87,8 +87,8 @@ The seed script inserts two sample leads and a booked appointment:
 INSERT INTO Leads (...)
     ('555-0001', 1, 'Eve', 'Example', '123 Main St', ...),
     ('555-0002', 2, 'John', 'Doe', '456 Oak Ave', ...);
-INSERT INTO Booked (phone, full_name, booked_date, booked_time, time_zone, realtor_id)
-VALUES ('555-0001', 'Eve Example', CURRENT_DATE, '10:00', 'UTC', 1);
+INSERT INTO Booked (phone, full_name, appointment_time, meeting_link, realtor_id)
+VALUES ('555-0001', 'Eve Example', NOW(), 'https://example.com/meet', 1);
 ```
 See [`database/seed.sql`](../database/seed.sql) for the full statements.
 


### PR DESCRIPTION
## Summary
- add `scheduled_messages` table with FKs to Leads and Realtor
- change `Booked` table to use a single `appointment_time` and `meeting_link`
- document updated schema in `database-schema.md`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841b544edb0832e901f5794cfe03e15