### PR TITLE
Fix scheduler insert missing realtor

### DIFF
--- a/backend/src/scheduler/scheduler.service.ts
+++ b/backend/src/scheduler/scheduler.service.ts
@@ -16,8 +16,19 @@ export class SchedulerService {
     time: string,
     content: string,
   ): Promise<void> {
+    const { data: lead, error } = await this.client
+      .from('leads')
+      .select('realtor_id')
+      .eq('phone', phone)
+      .maybeSingle();
+
+    if (error) throw error;
+    const realtorId = (lead as { realtor_id: number } | null)?.realtor_id;
+    if (!realtorId) throw new Error('Invalid phone number');
+
     await this.client.from('scheduled_messages').insert({
       phone,
+      realtor_id: realtorId,
       scheduled_time: time,
       message_type: 'text',
       message_text: content,


### PR DESCRIPTION
## Summary
- insert `realtor_id` when scheduling messages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6842168bc484832e8673514a0f8d6ba3