### PR TITLE
Fix null check for Luxon DateTime.toISO()

### DIFF
--- a/backend/src/booking/booking.service.ts
+++ b/backend/src/booking/booking.service.ts
@@ -4,10 +4,6 @@ import { MessengerService } from '../messenger/messenger.service';
 import { CalendarService } from '../calendar/calendar.service';
 import { DateTime } from 'luxon';
 
-/* eslint-disable @typescript-eslint/no-unsafe-assignment,
-  @typescript-eslint/no-unsafe-call,
-  @typescript-eslint/no-unsafe-member-access */
-
 export interface BookingInput {
   phone: string;
   full_name: string;
@@ -55,12 +51,15 @@ export class BookingService {
       },
     );
     const end = start.plus({ minutes: 30 });
+    const startIso = start.toISO();
+    const endIso = end.toISO();
+    if (!startIso || !endIso) throw new Error('Invalid booking time');
 
     await this.calendar.addEvent(input.realtor_id, {
       summary: `Meeting with ${input.full_name}`,
       description: `Phone: ${input.phone}`,
-      start: start.toISO(),
-      end: end.toISO(),
+      start: startIso,
+      end: endIso,
       calendarId: 'primary',
       phone: input.phone,
     });


### PR DESCRIPTION
## Summary
- handle DateTime.toISO possibly returning null when adding calendar events

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6842f76ca9ac832e929ddb5e3cc5fe0a