### PR TITLE
Fix master-switch deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ This repository hosts a monorepo used to experiment with lead generation and boo
    ```bash
    npm install
    ```
-2. Start the backend in development mode:
+2. Start the backend in development mode (optional):
    ```bash
 npm run start:dev
 ```
-3. Start all services together with the master switch:
+3. Build and launch everything with the master switch:
    ```bash
 npm run master-switch
 ```

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,6 +1,8 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { RedisModule } from '@nestjs-modules/ioredis';
+import { ServeStaticModule } from '@nestjs/serve-static';
+import { join } from 'path';
 
 import { AppController } from './app.controller';
 import { ConversationController } from './clientRedis/conversation.controller';
@@ -31,6 +33,17 @@ import { PromptService } from './agentHelp/prompt.service';
       isGlobal: true,
       envFilePath: 'backend/.env',
     }),
+
+    ServeStaticModule.forRoot([
+      {
+        rootPath: join(__dirname, '..', '..', 'frontend', 'site', 'dist'),
+        serveRoot: '/',
+      },
+      {
+        rootPath: join(__dirname, '..', '..', 'frontend', 'survey', 'dist'),
+        serveRoot: '/survey',
+      },
+    ]),
 
     RedisModule.forRoot({
       url: process.env.REDIS_URL,

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "start:dev": "nest start --watch -c backend/nest-cli.json -p backend/tsconfig.build.json",
     "start:debug": "nest start --debug --watch -c backend/nest-cli.json -p backend/tsconfig.build.json",
     "start:prod": "node backend/dist/main",
-    "master-switch": "concurrently \"npm run start:dev\" \"npm --workspace frontend/site run dev\" \"npm --workspace frontend/user-report run dev\"",
+    "master-switch": "npm run build && npm --workspace frontend/site run build && npm --workspace frontend/survey run build && npm run start:prod",
     "lint": "eslint \"{backend/src,frontend,libs,backend/test}/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",


### PR DESCRIPTION
## Summary
- serve `frontend/site` and `frontend/survey` builds via NestJS
- update `master-switch` script to build in production mode
- clarify README instructions for starting in production

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684302010390832eb1f52174d35203f1