### PR TITLE
Fix SPA routing for realtor pages

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,10 +1,20 @@
 import 'dotenv/config';
 import { NestFactory } from '@nestjs/core';
+import { NestExpressApplication } from '@nestjs/platform-express';
+import { join } from 'path';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
+  const app = await NestFactory.create<NestExpressApplication>(AppModule);
   app.setGlobalPrefix('api');
+
+  const expressApp = app.getHttpAdapter().getInstance();
+  expressApp.get(/^\/(?!api|survey).*/, (req, res) => {
+    res.sendFile(
+      join(__dirname, '..', '..', 'frontend', 'site', 'dist', 'index.html'),
+    );
+  });
+
   await app.listen(process.env.PORT ?? 3000);
 }
 void bootstrap();


### PR DESCRIPTION
## Summary
- serve frontend/site `index.html` for any non-API route
- ensure paths like `/c3d4e5f6-a7b8-6543-8765-3c4d5e6f7a8b` load correctly

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68430e389e9c832e91d5afa2307cd312