### PR TITLE
Run React previews with master switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,15 @@ This repository hosts a monorepo used to experiment with lead generation and boo
    ```bash
 npm run start:dev
 ```
-3. Build and launch everything with the master switch:
+3. Build and launch everything with the master switch. This compiles the backend
+   and both React apps, then starts the backend server together with Vite preview
+   servers for each site:
    ```bash
 npm run master-switch
 ```
+
+The landing page preview will be available at `http://localhost:4173` and the
+survey site at `http://localhost:4174`.
 
 To develop or build the front ends:
 
@@ -40,9 +45,7 @@ npm run build
 npm run preview    # optional: serve the built files locally
 ```
 
-When running the landing page, navigate to `http://localhost:5173/<realtorUUID>`.
-The user marker portion of the URL is optional and no longer required. The page fetches the
-realtor's video and calendar using the UUID provided in the URL.
+When running the landing page in development mode, navigate to `http://localhost:5173/<realtorUUID>`. When using the master switch or `npm run preview`, open `http://localhost:4173` instead. The user marker portion of the URL is optional and no longer required. The page fetches the realtor's video and calendar using the UUID provided in the URL.
 
 See the [docs directory](docs/README.md) for additional notes such as the database schema and sample scripts.
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "start:dev": "nest start --watch -c backend/nest-cli.json -p backend/tsconfig.build.json",
     "start:debug": "nest start --debug --watch -c backend/nest-cli.json -p backend/tsconfig.build.json",
     "start:prod": "node backend/dist/main",
-    "master-switch": "npm run build && npm --workspace frontend/site run build && npm --workspace frontend/survey run build && npm run start:prod",
+    "master-switch": "npm run build && npm --workspace frontend/site run build && npm --workspace frontend/survey run build && npx concurrently \"npm run start:prod\" \"npm --workspace frontend/site run preview -- --port 4173\" \"npm --workspace frontend/survey run preview -- --port 4174\"",
     "lint": "eslint \"{backend/src,frontend,libs,backend/test}/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",


### PR DESCRIPTION
## Summary
- run Vite preview servers for the `site` and `survey` front ends when invoking `npm run master-switch`
- document new behaviour and preview ports in README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68432e9cc64c832eb6f755548996c896