### PR TITLE
Start scheduler cron from server

### DIFF
--- a/backend/src/scheduler/scheduler.service.ts
+++ b/backend/src/scheduler/scheduler.service.ts
@@ -1,14 +1,29 @@
-import { Injectable } from '@nestjs/common';
+import {
+  Injectable,
+  OnModuleDestroy,
+  OnModuleInit,
+  Logger,
+} from '@nestjs/common';
 import { SupabaseClient, createClient } from '@supabase/supabase-js';
+import { Twilio } from 'twilio';
 
 @Injectable()
-export class SchedulerService {
+export class SchedulerService implements OnModuleInit, OnModuleDestroy {
   private readonly client: SupabaseClient<any>;
+  private readonly twilio: Twilio;
+  private readonly from: string;
+  private interval?: NodeJS.Timeout;
+  private readonly log = new Logger('SchedulerService');
 
   constructor() {
     const url = process.env.SUPABASE_URL ?? '';
     const key = process.env.SUPABASE_SERVICE_ROLE_KEY ?? '';
     this.client = createClient(url, key);
+    this.twilio = new Twilio(
+      process.env.TWILIO_ACCOUNT_SID ?? '',
+      process.env.TWILIO_AUTH_TOKEN ?? '',
+    );
+    this.from = process.env.TWILIO_PHONE_NUMBER ?? '';
   }
 
   async scheduleMessage(
@@ -61,5 +76,54 @@ export class SchedulerService {
       .update({ message_status: 'canceled' })
       .eq('phone', phone)
       .eq('message_status', 'pending');
+  }
+
+  async processDueMessages(): Promise<void> {
+    const now = new Date().toISOString();
+    const { data, error } = await this.client
+      .from('scheduled_messages')
+      .select('*')
+      .eq('message_status', 'pending')
+      .lte('scheduled_time', now);
+
+    if (error) {
+      this.log.error('Fetch error', error as Error);
+      return;
+    }
+
+    for (const row of data ?? []) {
+      try {
+        await this.twilio.messages.create({
+          body: row.message_text ?? '',
+          to: row.phone,
+          from: this.from,
+        });
+        await this.client
+          .from('scheduled_messages')
+          .update({ message_status: 'sent' })
+          .eq('id', row.id);
+        this.log.log(`Sent message ${row.id} to ${row.phone}`);
+      } catch (err) {
+        this.log.error(`Send failed for ${row.id}`, err as Error);
+        await this.client
+          .from('scheduled_messages')
+          .update({ message_status: 'failed' })
+          .eq('id', row.id);
+      }
+    }
+  }
+
+  onModuleInit(): void {
+    const intervalMs = Number(process.env.SCHEDULER_INTERVAL_MS ?? '60000');
+    this.log.log(`Starting scheduler cron every ${intervalMs}ms`);
+    this.interval = setInterval(() => {
+      void this.processDueMessages();
+    }, intervalMs);
+  }
+
+  onModuleDestroy(): void {
+    if (this.interval) {
+      clearInterval(this.interval);
+    }
   }
 }

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -61,7 +61,7 @@ Example data for local development is provided in [`database/seed.sql`](../datab
 - `message_status`
 - `message_text`
 - `created_at`
-- rows are processed by `backend/src/scheduler/cron.ts`
+- rows are processed by the cron job in `backend/src/scheduler/cron.ts`
 
 ### message_logs
 - `id` – primary key

--- a/docs/node-services.md
+++ b/docs/node-services.md
@@ -50,4 +50,4 @@ This functionality is now implemented inside the Nest backend.
   - `POST /schedule` – schedule an SMS with `phone`, `time` and `content` in the body
   - `POST /schedule/cancel/:phone` – cancel pending messages for a phone number
 - **Database**: uses the `scheduled_messages` table in Supabase
-- A cron job runs the `cron.ts` script to send due messages via Twilio
+- The Nest server automatically starts a job that periodically invokes `cron.ts` to send due messages via Twilio

--- a/docs/survey-flow.md
+++ b/docs/survey-flow.md
@@ -14,7 +14,7 @@ Once on the booking site two scenarios may occur:
 - **[2a\*] Immediate Booking** – if the user books a time within five minutes, a confirmation message is sent:
   > “Thank you for booking a meeting with {realtor_name} at {date} {time}. {realtor_name} will soon enter contact with you.”
   Sending additional messages does nothing.
-- **[2b\*] No Booking Yet** – if no booking is made within five minutes, a cron job schedules a reminder SMS via the Scheduler service.
+- **[2b\*] No Booking Yet** – if no booking is made within five minutes, the built-in cron job schedules a reminder SMS via the Scheduler service.
 
 Each booking writes a Google Calendar event and stores its link and phone number in Supabase. When users reschedule, the site reads updated times from Google Calendar and confirms the change.
 


### PR DESCRIPTION
## Summary
- add a cron runner inside `SchedulerService`
- cron runs every 60s by default and sends due messages
- document that the Nest server handles scheduled SMS sending

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint module not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846ea01dfdc832e8d12993dbfe9a660