### PR TITLE
Fix survey URL parsing and validate realtor UUID

### DIFF
--- a/backend/src/leads/leads.service.ts
+++ b/backend/src/leads/leads.service.ts
@@ -21,6 +21,7 @@ interface LeadInput {
 @Injectable()
 export class LeadsService {
   private readonly client: SupabaseClient<any>;
+  private readonly uuidRe = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
   constructor() {
     const url = process.env.SUPABASE_URL ?? '';
@@ -30,6 +31,14 @@ export class LeadsService {
 
   async createLead(input: LeadInput): Promise<void> {
     console.debug('[LeadsService] createLead called with', input);
+
+    if (!this.uuidRe.test(input.realtorUuid)) {
+      console.error(
+        '[LeadsService] invalid realtor uuid format',
+        input.realtorUuid,
+      );
+      throw new Error('Invalid realtor');
+    }
 
     const { data, error: realtorErr } = await this.client
       .from('realtor')
@@ -115,6 +124,10 @@ export class LeadsService {
 
   async findRealtor(uuid: string) {
     console.debug('[LeadsService] fetching realtor', uuid);
+    if (!this.uuidRe.test(uuid)) {
+      console.debug('[LeadsService] invalid uuid format', uuid);
+      return null;
+    }
     const { data, error } = await this.client
       .from('realtor')
       .select('realtor_id,f_name,e_name,video_url,website_url')

--- a/frontend/survey/src/App.jsx
+++ b/frontend/survey/src/App.jsx
@@ -6,7 +6,8 @@ export default function App() {
   useEffect(() => {
     const url = new URL(window.location.href);
     const parts = url.pathname.split('/').filter(Boolean);
-    const realtorUuid = parts[0] || '';
+    const idx = parts[0] === 'survey' ? 1 : 0;
+    const realtorUuid = parts[idx] || '';
 
     const form = document.getElementById('surveyForm');
     const prevBtn = document.getElementById('prevBtn');


### PR DESCRIPTION
## Summary
- fix survey app path parsing to correctly capture realtor UUID when served from `/survey`
- validate realtor UUID format in LeadsService to avoid Supabase errors

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find module '@typescript-eslint/eslint-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_6846f4881338832e8ec84f53f7ddf008