### PR TITLE
Update onboarding doc and OAuth callback

### DIFF
--- a/backend/src/calendar/calendar.controller.ts
+++ b/backend/src/calendar/calendar.controller.ts
@@ -15,11 +15,6 @@ import { CalendarService, EventInput } from './calendar.service';
 export class CalendarController {
   constructor(private readonly calendar: CalendarService) {}
 
-  @Get('oauth/:realtorId')
-  getAuthUrl(@Param('realtorId') realtorId: number) {
-    return { url: this.calendar.generateAuthUrl(realtorId) };
-  }
-
   @Get('oauth/callback')
   @HttpCode(200)
   async oauthCallback(
@@ -29,6 +24,11 @@ export class CalendarController {
     const realtorId = Number(state);
     await this.calendar.handleOAuthCallback(code, realtorId);
     return { status: 'linked' };
+  }
+
+  @Get('oauth/:realtorId')
+  getAuthUrl(@Param('realtorId') realtorId: number) {
+    return { url: this.calendar.generateAuthUrl(realtorId) };
   }
 
   @Post(':realtorId/events')

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -5,15 +5,16 @@ This short guide explains how to link a Google Calendar so that bookings created
 The admin dashboard exposes a **Link Google Calendar** button during the onboarding process. Clicking it will open the Google consent screen using the `/api/calendar/oauth/<realtorId>` endpoint. After granting access the backend receives a refresh token so future calendar calls work without additional prompts.
 
 1. Ensure the backend is running and accessible. The `GOOGLE_REDIRECT_URI` environment variable must point to
-   `http://<server>/api/calendar/oauth/callback` (or your deployed URL).
+   `http://myrealvaluation.com/api/calendar/oauth/callback` (or your deployed URL).
 2. Obtain your personal authorization link by calling:
    ```bash
-   curl http://<server>/api/calendar/oauth/<realtorId>
+   curl http://myrealvaluation.com/api/calendar/oauth/<realtorId>
    ```
    The response contains a `url` field. Open it in your browser.
 3. Grant access to the requested Google account and confirm the consent screen.
-4. After approval you will be redirected back to the callback endpoint and the
-   backend stores your refresh token in Supabase.
+4. After approval you will be redirected back to the callback endpoint. At this
+   point the server automatically saves your Google refresh token in the
+   database so future calendar calls work without any additional steps.
 
 Once this flow is completed, the application can create, update and delete
 calendar events without asking for permission again. Tokens are refreshed


### PR DESCRIPTION
## Summary
- fix docs/onboarding instructions to use myrealvaluation.com
- mention that OAuth credentials are stored automatically
- ensure callback route handles OAuth before :realtorId to save credentials

## Testing
- `npm test`
- `npm run lint` *(fails: Unsafe member access errors)*

------
https://chatgpt.com/codex/tasks/task_e_6846f67d7184832e8442f07fbe85a89a