### PR TITLE
Ensure scheduled SMS gets logged

### DIFF
--- a/backend/src/scheduler/cron.ts
+++ b/backend/src/scheduler/cron.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access */
 import { createClient } from '@supabase/supabase-js';
 import { Twilio } from 'twilio';
+import Redis from 'ioredis';
 
 const supabase = createClient<any>(
   process.env.SUPABASE_URL ?? '',
@@ -12,6 +13,8 @@ const twilio = new Twilio(
   process.env.TWILIO_AUTH_TOKEN ?? '',
 );
 const FROM = process.env.TWILIO_PHONE_NUMBER ?? '';
+const redis = new Redis(process.env.REDIS_URL ?? '');
+const LIST = (phone: string) => `phone:${phone}:json`;
 
 export async function handler(): Promise<void> {
   const now = new Date().toISOString();
@@ -41,12 +44,20 @@ export async function handler(): Promise<void> {
         .from('scheduled_messages')
         .update({ message_status: 'sent' })
         .eq('id', row.id);
+      await redis.rpush(
+        LIST(row.phone),
+        JSON.stringify({ role: 'assistant', content: row.message_text ?? '' }),
+      );
     } catch (err) {
       console.error(`Send failed for ${row.id}`, err);
       await supabase
         .from('scheduled_messages')
         .update({ message_status: 'failed' })
         .eq('id', row.id);
+      await redis.rpush(
+        LIST(row.phone),
+        JSON.stringify({ role: 'assistant', content: row.message_text ?? '' }),
+      );
     }
   }
 


### PR DESCRIPTION
## Summary
- log all outgoing SMS into the conversation history
- include conversation logging in scheduler cron script as well

## Testing
- `npm run lint` *(fails: Cannot find package `@eslint/js`)*
- `npm test` *(fails: `jest` not found)*
- `npm run build` *(fails: `nest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846fd250590832e9bb8dbb535eb29b5