### PR TITLE
Add Docker setup for backend and frontends

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,3 +182,18 @@ All services share environment variables for:
 
 
 
+
+## Docker Setup
+
+To run the backend, landing page, survey site and Redis locally using Docker compose:
+
+```bash
+docker-compose up --build
+```
+
+The services will be available at:
+
+- Backend: <http://localhost:3000>
+- Landing page: <http://localhost:4173>
+- Survey site: <http://localhost:4174>
+- Redis: localhost port 6379

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package*.json ./
+COPY backend ./backend
+RUN npm install --omit=dev && npm run build
+EXPOSE 3000
+CMD ["npm", "run", "start:prod"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '3.8'
+services:
+  redis:
+    image: redis:7
+    ports:
+      - '6379:6379'
+  backend:
+    build:
+      context: .
+      dockerfile: backend/Dockerfile
+    environment:
+      REDIS_URL: redis://redis:6379
+    depends_on:
+      - redis
+    ports:
+      - '3000:3000'
+  site:
+    build:
+      context: .
+      dockerfile: frontend/site/Dockerfile
+    depends_on:
+      - backend
+    ports:
+      - '4173:80'
+  survey:
+    build:
+      context: .
+      dockerfile: frontend/survey/Dockerfile
+    depends_on:
+      - backend
+    ports:
+      - '4174:80'

--- a/frontend/site/Dockerfile
+++ b/frontend/site/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:20-alpine AS build
+WORKDIR /app/site
+COPY frontend/site ./
+RUN npm install && npm run build
+
+FROM nginx:alpine
+COPY frontend/site/nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/site/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/site/nginx.conf
+++ b/frontend/site/nginx.conf
@@ -1,0 +1,10 @@
+server {
+    listen 80;
+    location /api/ {
+        proxy_pass http://backend:3000/api/;
+    }
+    location / {
+        root /usr/share/nginx/html;
+        try_files $uri /index.html;
+    }
+}

--- a/frontend/survey/Dockerfile
+++ b/frontend/survey/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:20-alpine AS build
+WORKDIR /app/survey
+COPY frontend/survey ./
+RUN npm install && npm run build
+
+FROM nginx:alpine
+COPY frontend/survey/nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/survey/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/survey/nginx.conf
+++ b/frontend/survey/nginx.conf
@@ -1,0 +1,10 @@
+server {
+    listen 80;
+    location /api/ {
+        proxy_pass http://backend:3000/api/;
+    }
+    location / {
+        root /usr/share/nginx/html;
+        try_files $uri /index.html;
+    }
+}


### PR DESCRIPTION
## Summary
- add Dockerfiles for backend, landing page and survey app
- create nginx configs for frontend containers
- define `docker-compose.yml` with backend, Redis, and two front-end services
- document Docker usage in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846fdf84204832e990124aef4d9e571