### PR TITLE
Separate Nest API container

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ All services share environment variables for:
 
 ## Docker Setup
 
-To run the backend, landing page, survey site and Redis locally using Docker compose:
+To run the API, landing page, survey site and Redis locally using Docker compose:
 
 ```bash
 docker-compose up --build
@@ -193,7 +193,7 @@ docker-compose up --build
 
 The services will be available at:
 
-- Backend: <http://localhost:3000>
+- API: <http://localhost:3000>
 - Landing page: <http://localhost:4173>
 - Survey site: <http://localhost:4174>
 - Redis: localhost port 6379

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     image: redis:7
     ports:
       - '6379:6379'
-  backend:
+  api:
     build:
       context: .
       dockerfile: backend/Dockerfile
@@ -19,7 +19,7 @@ services:
       context: .
       dockerfile: frontend/site/Dockerfile
     depends_on:
-      - backend
+      - api
     ports:
       - '4173:80'
   survey:
@@ -27,6 +27,6 @@ services:
       context: .
       dockerfile: frontend/survey/Dockerfile
     depends_on:
-      - backend
+      - api
     ports:
       - '4174:80'

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -22,7 +22,7 @@ This guide explains how to configure the project for local development and how t
    ```bash
    npm run master-switch
    ```
-   - Backend API: <http://localhost:3000>
+   - API: <http://localhost:3000>
    - Landing page: <http://localhost:4173>
    - Survey site: <http://localhost:4174>
 

--- a/frontend/site/nginx.conf
+++ b/frontend/site/nginx.conf
@@ -1,7 +1,7 @@
 server {
     listen 80;
     location /api/ {
-        proxy_pass http://backend:3000/api/;
+        proxy_pass http://api:3000/api/;
     }
     location / {
         root /usr/share/nginx/html;

--- a/frontend/survey/nginx.conf
+++ b/frontend/survey/nginx.conf
@@ -1,7 +1,7 @@
 server {
     listen 80;
     location /api/ {
-        proxy_pass http://backend:3000/api/;
+        proxy_pass http://api:3000/api/;
     }
     location / {
         root /usr/share/nginx/html;


### PR DESCRIPTION
## Summary
- rename backend service to `api`
- point nginx proxies at new `api` container
- document updated container name in README and setup guide

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68470bac8a1c832e9a177793460987ec