### PR TITLE
Add curl guide for sending messages

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,3 +5,4 @@ This directory holds supplementary notes and guides related to the Lead Manageme
 - [Environment Variables](environment-variables.md)
 - [Survey and Site Flow](survey-flow.md)
 - [Setup Guide](setup-guide.md)
+- [Sending Test Messages](message-testing.md)

--- a/docs/message-testing.md
+++ b/docs/message-testing.md
@@ -1,0 +1,25 @@
+# Sending Test Messages
+
+This guide explains how to manually trigger the messaging flow using `curl`.
+It can be used to verify Twilio integration and the AI assistant's response.
+
+## Prerequisites
+- The backend server must be running. By default it listens on `http://localhost:3000`.
+- Environment variables for Twilio and Supabase need to be configured in `backend/.env`.
+
+## Example Request
+Send a POST request to the `/message` endpoint with the target phone number and the message text:
+
+```bash
+curl -X POST http://localhost:3000/message \
+  -H "Content-Type: application/json" \
+  -d '{"phone": "+15551234567", "message": "Hello"}'
+```
+
+The server replies with the assistant's message in JSON:
+
+```json
+{"assistant": "Thanks for reaching out!"}
+```
+
+A record is stored in the `message_logs` table and the conversation history is updated in Redis.


### PR DESCRIPTION
## Summary
- add `message-testing.md` with instructions for sending a message using `curl`
- link the new doc from `docs/README.md`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847156be75c832e8fd11215fdc235f8