### PR TITLE
Add system message lookup endpoint

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -23,6 +23,7 @@ import { LeadsService } from './leads/leads.service';
 import { MessengerService } from './messenger/messenger.service';
 import { BookingService } from './booking/booking.service';
 import { BookingController } from './booking/booking.controller';
+import { SystemMessageController } from './system-message.controller';
 
 import { OpenAiService } from './agentHelp/openai.service';
 import { PromptService } from './agentHelp/prompt.service';
@@ -58,6 +59,7 @@ import { PromptService } from './agentHelp/prompt.service';
     SchedulerController,
     LeadsController,
     BookingController,
+    SystemMessageController,
   ],
   providers: [
     AppService,

--- a/backend/src/system-message.controller.ts
+++ b/backend/src/system-message.controller.ts
@@ -1,0 +1,20 @@
+import { Controller, Get, Param } from '@nestjs/common';
+import { PromptService } from './agentHelp/prompt.service';
+import { LeadsService } from './leads/leads.service';
+
+@Controller('systemmessage')
+export class SystemMessageController {
+  constructor(
+    private readonly prompt: PromptService,
+    private readonly leads: LeadsService,
+  ) {}
+
+  @Get(':phone')
+  async getSystemMessage(@Param('phone') phone: string) {
+    const info = await this.leads.getInfoForAgent(phone);
+    const message = info
+      ? this.prompt.systemMessage(info.realtorName, info.answers)
+      : this.prompt.systemMessage();
+    return { systemMessage: message };
+  }
+}


### PR DESCRIPTION
## Summary
- expose new `/api/systemmessage/:phone` endpoint to fetch PromptService system message
- wire SystemMessageController into AppModule

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684716619ef4832eb908c701de4d0d65