### PR TITLE
Fix duplicate message logging in conversation history

### DIFF
--- a/backend/src/agentLogic/agent.service.ts
+++ b/backend/src/agentLogic/agent.service.ts
@@ -49,7 +49,7 @@ export class AgentService {
     const calls = reply.tool_calls ?? [];
     if (calls.length === 0) {
       if (reply.content) {
-        await this.messenger.sendSms(phone, reply.content);
+        await this.messenger.sendSms(phone, reply.content, false);
       }
       return reply.content ?? '';
     }

--- a/backend/src/messenger/messenger.service.ts
+++ b/backend/src/messenger/messenger.service.ts
@@ -21,7 +21,11 @@ export class MessengerService {
     );
   }
 
-  async sendSms(phone: string, text: string): Promise<void> {
+  async sendSms(
+    phone: string,
+    text: string,
+    storeMessage = true,
+  ): Promise<void> {
     try {
       await this.twilio.messages.create({
         body: text,
@@ -34,7 +38,9 @@ export class MessengerService {
         message_text: text,
         status: 'sent',
       });
-      await this.conversation.store(phone, { role: 'assistant', content: text });
+      if (storeMessage) {
+        await this.conversation.store(phone, { role: 'assistant', content: text });
+      }
     } catch (err) {
       this.log.error('Failed to send SMS', err as Error);
       await this.supabase.from('message_logs').insert({
@@ -43,7 +49,9 @@ export class MessengerService {
         message_text: text,
         status: 'failed',
       });
-      await this.conversation.store(phone, { role: 'assistant', content: text });
+      if (storeMessage) {
+        await this.conversation.store(phone, { role: 'assistant', content: text });
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- allow MessengerService.sendSms to optionally skip storing in conversation history
- avoid storing assistant replies twice in AgentService

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: missing @eslint/js)*
- `npm run build` *(fails: nest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684727ec2b10832eb99813f7f17de863