### PR TITLE
Add realtor onboarding interface

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -24,6 +24,8 @@ import { MessengerService } from './messenger/messenger.service';
 import { BookingService } from './booking/booking.service';
 import { BookingController } from './booking/booking.controller';
 import { SystemMessageController } from './system-message.controller';
+import { RealtorController } from './realtor/realtor.controller';
+import { RealtorService } from './realtor/realtor.service';
 
 import { OpenAiService } from './agentHelp/openai.service';
 import { PromptService } from './agentHelp/prompt.service';
@@ -44,6 +46,18 @@ import { PromptService } from './agentHelp/prompt.service';
         rootPath: join(__dirname, '..', '..', 'frontend', 'survey', 'dist'),
         serveRoot: '/survey',
       },
+      {
+        rootPath: join(
+          __dirname,
+          '..',
+          '..',
+          'frontend',
+          'RealtorInterface',
+          'Onboarding',
+          'dist',
+        ),
+        serveRoot: '/realtor',
+      },
     ),
 
     RedisModule.forRoot({
@@ -59,6 +73,7 @@ import { PromptService } from './agentHelp/prompt.service';
     SchedulerController,
     LeadsController,
     BookingController,
+    RealtorController,
     SystemMessageController,
   ],
   providers: [
@@ -73,6 +88,7 @@ import { PromptService } from './agentHelp/prompt.service';
     LeadsService,
     MessengerService,
     BookingService,
+    RealtorService,
   ],
 })
 export class AppModule {}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -9,7 +9,7 @@ async function bootstrap() {
   app.setGlobalPrefix('api');
 
   const expressApp = app.getHttpAdapter().getInstance();
-  expressApp.get(/^\/(?!api|survey).*/, (req, res) => {
+  expressApp.get(/^\/(?!api|survey|realtor).*/, (req, res) => {
     res.sendFile(
       join(__dirname, '..', '..', 'frontend', 'site', 'dist', 'index.html'),
     );

--- a/backend/src/realtor/realtor.controller.ts
+++ b/backend/src/realtor/realtor.controller.ts
@@ -1,0 +1,13 @@
+import { Body, Controller, HttpCode, Post } from '@nestjs/common';
+import { RealtorInput, RealtorService } from './realtor.service';
+
+@Controller('realtor')
+export class RealtorController {
+  constructor(private readonly realtors: RealtorService) {}
+
+  @Post()
+  @HttpCode(201)
+  async create(@Body() body: RealtorInput) {
+    return this.realtors.createRealtor(body);
+  }
+}

--- a/backend/src/realtor/realtor.service.ts
+++ b/backend/src/realtor/realtor.service.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@nestjs/common';
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+
+export interface RealtorInput {
+  name: string;
+  email: string;
+  phone: string;
+}
+
+@Injectable()
+export class RealtorService {
+  private readonly client: SupabaseClient<any>;
+
+  constructor() {
+    const url = process.env.SUPABASE_URL ?? '';
+    const key = process.env.SUPABASE_SERVICE_ROLE_KEY ?? '';
+    this.client = createClient(url, key);
+  }
+
+  async createRealtor(input: RealtorInput) {
+    const [first, ...rest] = input.name.trim().split(' ');
+    const last = rest.join(' ');
+    const { data, error } = await this.client
+      .from('realtor')
+      .insert({ f_name: first, e_name: last, email: input.email, phone: input.phone })
+      .select('uuid,realtor_id')
+      .single();
+    if (error) throw error;
+    return data as { uuid: string; realtor_id: number };
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,3 +30,11 @@ services:
       - api
     ports:
       - '4174:80'
+  onboarding:
+    build:
+      context: .
+      dockerfile: frontend/RealtorInterface/Onboarding/Dockerfile
+    depends_on:
+      - api
+    ports:
+      - '4175:80'

--- a/frontend/RealtorInterface/Onboarding/Dockerfile
+++ b/frontend/RealtorInterface/Onboarding/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:20-alpine AS build
+WORKDIR /app/onboarding
+COPY frontend/RealtorInterface/Onboarding ./
+RUN npm install && npm run build
+
+FROM nginx:alpine
+COPY frontend/RealtorInterface/Onboarding/nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/onboarding/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/RealtorInterface/Onboarding/index.html
+++ b/frontend/RealtorInterface/Onboarding/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Realtor Onboarding</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/RealtorInterface/Onboarding/nginx.conf
+++ b/frontend/RealtorInterface/Onboarding/nginx.conf
@@ -1,0 +1,10 @@
+server {
+    listen 80;
+    location /api/ {
+        proxy_pass http://api:3000/api/;
+    }
+    location / {
+        root /usr/share/nginx/html;
+        try_files $uri /index.html;
+    }
+}

--- a/frontend/RealtorInterface/Onboarding/package.json
+++ b/frontend/RealtorInterface/Onboarding/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "realtor-onboarding",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@types/react": "^19.1.6",
+    "@types/react-dom": "^19.1.5",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/frontend/RealtorInterface/Onboarding/src/App.jsx
+++ b/frontend/RealtorInterface/Onboarding/src/App.jsx
@@ -1,0 +1,93 @@
+import React, { useState } from 'react';
+
+export default function App() {
+  const [step, setStep] = useState(1);
+  const [info, setInfo] = useState({ name: '', email: '', phone: '' });
+  const [realtor, setRealtor] = useState(null);
+  const [password, setPassword] = useState('');
+
+  const handleFirstSubmit = async (e) => {
+    e.preventDefault();
+    const res = await fetch('/api/realtor', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(info),
+    });
+    const data = await res.json();
+    setRealtor(data);
+    setStep(2);
+  };
+
+  const handleCalendarLink = async () => {
+    if (!realtor) return;
+    const res = await fetch(`/api/calendar/oauth/${realtor.realtor_id}`);
+    const json = await res.json();
+    window.location.href = json.url;
+  };
+
+  const handleSecondSubmit = (e) => {
+    e.preventDefault();
+    alert('Onboarding complete!');
+  };
+
+  return (
+    <div style={{ padding: '20px', maxWidth: '500px', margin: '0 auto' }}>
+      {step === 1 && (
+        <form onSubmit={handleFirstSubmit}>
+          <h2>Step 1: Your Information</h2>
+          <p>Please provide your details to create your account.</p>
+          <input
+            type="text"
+            placeholder="Full name"
+            value={info.name}
+            onChange={(e) => setInfo({ ...info, name: e.target.value })}
+            required
+          />
+          <br />
+          <input
+            type="email"
+            placeholder="Email"
+            value={info.email}
+            onChange={(e) => setInfo({ ...info, email: e.target.value })}
+          />
+          <br />
+          <input
+            type="text"
+            placeholder="Phone"
+            value={info.phone}
+            onChange={(e) => setInfo({ ...info, phone: e.target.value })}
+            required
+          />
+          <br />
+          <button type="submit">Submit</button>
+        </form>
+      )}
+
+      {step === 2 && (
+        <form onSubmit={handleSecondSubmit}>
+          <h2>Step 2: Connect Calendar</h2>
+          <p>
+            Click the button below to link your Google Calendar. Make sure you are
+            logged into the correct Google account. If you encounter any issues,
+            try using an incognito window or another browser.
+          </p>
+          <button type="button" onClick={handleCalendarLink}>
+            Connect Google Calendar
+          </button>
+          <p>
+            After granting access you will be redirected back here. Set a
+            temporary password below to finish your setup.
+          </p>
+          <input
+            type="password"
+            placeholder="Temporary Password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+          <br />
+          <button type="submit">Finish</button>
+        </form>
+      )}
+    </div>
+  );
+}

--- a/frontend/RealtorInterface/Onboarding/src/main.jsx
+++ b/frontend/RealtorInterface/Onboarding/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/frontend/RealtorInterface/Onboarding/vite.config.js
+++ b/frontend/RealtorInterface/Onboarding/vite.config.js
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  base: './',
+  plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:3000',
+    },
+  },
+});

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "author": "",
   "private": true,
   "workspaces": [
-    "frontend/*"
+    "frontend/*",
+    "frontend/RealtorInterface/*"
   ],
   "license": "UNLICENSED",
   "scripts": {
@@ -15,7 +16,7 @@
     "start:dev": "nest start --watch -c backend/nest-cli.json -p backend/tsconfig.build.json",
     "start:debug": "nest start --debug --watch -c backend/nest-cli.json -p backend/tsconfig.build.json",
     "start:prod": "node backend/dist/main",
-    "master-switch": "npm run build && npm --workspace frontend/site run build && npm --workspace frontend/survey run build && npx concurrently \"npm run start:prod\" \"npm --workspace frontend/site run preview -- --port 4173\" \"npm --workspace frontend/survey run preview -- --port 4174\"",
+    "master-switch": "npm run build && npm --workspace frontend/site run build && npm --workspace frontend/survey run build && npm --workspace frontend/RealtorInterface/Onboarding run build && npx concurrently \"npm run start:prod\" \"npm --workspace frontend/site run preview -- --port 4173\" \"npm --workspace frontend/survey run preview -- --port 4174\" \"npm --workspace frontend/RealtorInterface/Onboarding run preview -- --port 4175\"",
     "lint": "eslint \"{backend/src,frontend,libs,backend/test}/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",


### PR DESCRIPTION
## Summary
- implement new onboarding React app for realtors
- allow creating realtors via new API endpoints
- wire onboarding into backend static hosting
- serve new interface via docker and dev script

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_684827d81b74832e940baab775c4ea32