### PR TITLE
Implement Lead Reports interface

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -26,6 +26,8 @@ import { BookingController } from './booking/booking.controller';
 import { SystemMessageController } from './system-message.controller';
 import { RealtorController } from './realtor/realtor.controller';
 import { RealtorService } from './realtor/realtor.service';
+import { ReportsController } from './reports/reports.controller';
+import { ReportsService } from './reports/reports.service';
 
 import { OpenAiService } from './agentHelp/openai.service';
 import { PromptService } from './agentHelp/prompt.service';
@@ -58,6 +60,18 @@ import { PromptService } from './agentHelp/prompt.service';
         ),
         serveRoot: '/realtor',
       },
+      {
+        rootPath: join(
+          __dirname,
+          '..',
+          '..',
+          'frontend',
+          'RealtorInterface',
+          'LeadReports',
+          'dist',
+        ),
+        serveRoot: '/LeadReports',
+      },
     ),
 
     RedisModule.forRoot({
@@ -75,6 +89,7 @@ import { PromptService } from './agentHelp/prompt.service';
     BookingController,
     RealtorController,
     SystemMessageController,
+    ReportsController,
   ],
   providers: [
     AppService,
@@ -89,6 +104,7 @@ import { PromptService } from './agentHelp/prompt.service';
     MessengerService,
     BookingService,
     RealtorService,
+    ReportsService,
   ],
 })
 export class AppModule {}

--- a/backend/src/clientRedis/conversation.service.ts
+++ b/backend/src/clientRedis/conversation.service.ts
@@ -37,4 +37,9 @@ export class ConversationService {
         (m): m is OpenAI.Chat.ChatCompletionMessageParam => m !== undefined,
       );
   }
+
+  /*---------------  LENGTH  ----------------*/
+  async length(phone: string): Promise<number> {
+    return this.redis.llen(LIST(phone));
+  }
 }

--- a/backend/src/leads/leads.service.ts
+++ b/backend/src/leads/leads.service.ts
@@ -218,4 +218,68 @@ export class LeadsService {
 
     return { realtorName, answers };
   }
+
+  async getLeadReport(phone: string): Promise<{
+    name: string;
+    phone: string;
+    address: string | null;
+    answers: { question: string; answer: string }[];
+  } | null> {
+    const { data } = await this.client
+      .from('leads')
+      .select(
+        `first_name,last_name,phone,address,home_type,bedrooms,bathrooms,sqft,home_built,occupancy,sell_time,working_with_agent,looking_to_buy`,
+      )
+      .eq('phone', phone)
+      .maybeSingle();
+    const lead =
+      (data as {
+        first_name?: string;
+        last_name?: string;
+        phone: string;
+        address?: string;
+        home_type?: string;
+        bedrooms?: string;
+        bathrooms?: string;
+        sqft?: string;
+        home_built?: string;
+        occupancy?: string;
+        sell_time?: string;
+        working_with_agent?: string;
+        looking_to_buy?: string;
+      } | null) ?? null;
+    if (!lead) return null;
+
+    const bool = (v?: string) => {
+      if (!v) return '';
+      return v.toLowerCase() === 'yes'
+        ? 'Yes'
+        : v.toLowerCase() === 'no'
+          ? 'No'
+          : '';
+    };
+
+    const answers = [
+      { question: 'ZIP code', answer: lead.address ?? '' },
+      { question: 'Home type', answer: lead.home_type ?? '' },
+      { question: 'Bedrooms', answer: lead.bedrooms ?? '' },
+      { question: 'Bathrooms', answer: lead.bathrooms ?? '' },
+      { question: 'Square footage', answer: lead.sqft ?? '' },
+      { question: 'Year built', answer: lead.home_built ?? '' },
+      { question: 'Occupancy', answer: lead.occupancy ?? '' },
+      { question: 'Selling timeframe', answer: lead.sell_time ?? '' },
+      {
+        question: 'Working with an agent',
+        answer: bool(lead.working_with_agent),
+      },
+      { question: 'Looking to buy', answer: bool(lead.looking_to_buy) },
+    ].filter((a) => a.answer);
+
+    return {
+      name: `${lead.first_name ?? ''} ${lead.last_name ?? ''}`.trim(),
+      phone: lead.phone,
+      address: lead.address ?? null,
+      answers,
+    };
+  }
 }

--- a/backend/src/reports/reports.controller.ts
+++ b/backend/src/reports/reports.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get, Param } from '@nestjs/common';
+import { ReportsService } from './reports.service';
+
+@Controller('reports')
+export class ReportsController {
+  constructor(private readonly reports: ReportsService) {}
+
+  @Get(':phone')
+  async get(@Param('phone') phone: string) {
+    return this.reports.getReport(phone);
+  }
+}

--- a/backend/src/reports/reports.service.ts
+++ b/backend/src/reports/reports.service.ts
@@ -1,0 +1,97 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRedis } from '@nestjs-modules/ioredis';
+import { Redis } from 'ioredis';
+import { LeadsService } from '../leads/leads.service';
+import { ConversationService } from '../clientRedis/conversation.service';
+import { OpenAiService } from '../agentHelp/openai.service';
+
+@Injectable()
+export class ReportsService {
+  constructor(
+    private readonly leads: LeadsService,
+    private readonly conversation: ConversationService,
+    private readonly openai: OpenAiService,
+    @InjectRedis() private readonly redis: Redis,
+  ) {}
+
+  private surveyKey(phone: string) {
+    return `report:${phone}:survey`;
+  }
+  private messageKey(phone: string) {
+    return `report:${phone}:messages`;
+  }
+  private messageCountKey(phone: string) {
+    return `report:${phone}:msgcount`;
+  }
+
+  async getReport(phone: string) {
+    const lead = await this.leads.getLeadReport(phone);
+    if (!lead) return null;
+
+    const surveySummary = await this.getSurveySummary(phone, lead.answers);
+    const messageSummary = await this.getMessageSummary(phone);
+
+    return {
+      name: lead.name,
+      phone: lead.phone,
+      address: lead.address,
+      zipcode: lead.address,
+      surveySummary,
+      messageSummary,
+    };
+  }
+
+  private async getSurveySummary(
+    phone: string,
+    answers: { question: string; answer: string }[],
+  ): Promise<string> {
+    const key = this.surveyKey(phone);
+    const cached = await this.redis.get(key);
+    if (cached) return cached;
+
+    if (answers.length === 0) return '';
+    const content =
+      'Summarize these survey answers:\n' +
+      answers.map((a) => `${a.question}: ${a.answer}`).join('\n');
+    const reply = await this.openai.chat(
+      [
+        { role: 'user', content },
+      ],
+      'gpt-4o-mini',
+    );
+    const summary = reply.content ?? '';
+    await this.redis.set(key, summary);
+    return summary;
+  }
+
+  private async getMessageSummary(phone: string): Promise<string> {
+    const currentLen = await this.conversation.length(phone);
+    const [cached, countRaw] = await this.redis.mget(
+      this.messageKey(phone),
+      this.messageCountKey(phone),
+    );
+    const cachedCount = countRaw ? parseInt(countRaw, 10) : 0;
+    if (cached && cachedCount === currentLen) return cached;
+
+    const history = await this.conversation.fetchAll(phone);
+    if (history.length === 0) return '';
+    const text = history
+      .map((m) => `${m.role}: ${m.content}`)
+      .join('\n')
+      .slice(-12000);
+    const reply = await this.openai.chat(
+      [
+        { role: 'user', content: `Summarize this conversation:\n${text}` },
+      ],
+      'gpt-4o-mini',
+    );
+    const summary = reply.content ?? '';
+    await this.redis.mset(
+      this.messageKey(phone),
+      summary,
+      this.messageCountKey(phone),
+      String(currentLen),
+    );
+    return summary;
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,3 +38,11 @@ services:
       - api
     ports:
       - '4175:80'
+  leadreports:
+    build:
+      context: .
+      dockerfile: frontend/RealtorInterface/LeadReports/Dockerfile
+    depends_on:
+      - api
+    ports:
+      - '4176:80'

--- a/frontend/RealtorInterface/LeadReports/Dockerfile
+++ b/frontend/RealtorInterface/LeadReports/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:20-alpine AS build
+WORKDIR /app/reports
+COPY frontend/RealtorInterface/LeadReports ./
+RUN npm install && npm run build
+
+FROM nginx:alpine
+COPY frontend/RealtorInterface/LeadReports/nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/reports/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/RealtorInterface/LeadReports/index.html
+++ b/frontend/RealtorInterface/LeadReports/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Lead Report</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/RealtorInterface/LeadReports/nginx.conf
+++ b/frontend/RealtorInterface/LeadReports/nginx.conf
@@ -1,0 +1,10 @@
+server {
+    listen 80;
+    location /api/ {
+        proxy_pass http://api:3000/api/;
+    }
+    location / {
+        root /usr/share/nginx/html;
+        try_files $uri /index.html;
+    }
+}

--- a/frontend/RealtorInterface/LeadReports/package.json
+++ b/frontend/RealtorInterface/LeadReports/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "lead-reports",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@types/react": "^19.1.6",
+    "@types/react-dom": "^19.1.5",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/frontend/RealtorInterface/LeadReports/src/App.jsx
+++ b/frontend/RealtorInterface/LeadReports/src/App.jsx
@@ -1,0 +1,31 @@
+import React, { useEffect, useState } from 'react';
+
+export default function App() {
+  const [report, setReport] = useState(null);
+  const phone = window.location.pathname.split('/').pop();
+
+  useEffect(() => {
+    async function fetchReport() {
+      const res = await fetch(`/api/reports/${encodeURIComponent(phone)}`);
+      const data = await res.json();
+      setReport(data);
+    }
+    fetchReport();
+  }, [phone]);
+
+  if (!report) return <div>Loading...</div>;
+
+  return (
+    <div style={{ padding: '20px', maxWidth: '600px', margin: '0 auto' }}>
+      <h1>Lead Report</h1>
+      <p><strong>Name:</strong> {report.name || 'N/A'}</p>
+      <p><strong>Phone:</strong> {report.phone}</p>
+      <p><strong>Address:</strong> {report.address || 'N/A'}</p>
+      <p><strong>Zipcode:</strong> {report.zipcode || 'N/A'}</p>
+      <h2>Survey Summary</h2>
+      <p>{report.surveySummary || 'No survey data'}</p>
+      <h2>Message Summary</h2>
+      <p>{report.messageSummary || 'No messages'}</p>
+    </div>
+  );
+}

--- a/frontend/RealtorInterface/LeadReports/src/main.jsx
+++ b/frontend/RealtorInterface/LeadReports/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/frontend/RealtorInterface/LeadReports/vite.config.js
+++ b/frontend/RealtorInterface/LeadReports/vite.config.js
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  base: './',
+  plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:3000',
+    },
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.1",
       "license": "UNLICENSED",
       "workspaces": [
-        "frontend/*"
+        "frontend/*",
+        "frontend/RealtorInterface/*"
       ],
       "dependencies": {
         "@nestjs-modules/ioredis": "^2.0.2",
@@ -59,6 +60,34 @@
         "tsconfig-paths": "^4.2.0",
         "typescript": "^5.7.3",
         "typescript-eslint": "^8.20.0"
+      }
+    },
+    "frontend/RealtorInterface/LeadReports": {
+      "name": "lead-reports",
+      "version": "0.1.0",
+      "dependencies": {
+        "@types/react": "^19.1.6",
+        "@types/react-dom": "^19.1.5",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+      },
+      "devDependencies": {
+        "@vitejs/plugin-react": "^4.0.0",
+        "vite": "^5.0.0"
+      }
+    },
+    "frontend/RealtorInterface/Onboarding": {
+      "name": "realtor-onboarding",
+      "version": "0.1.0",
+      "dependencies": {
+        "@types/react": "^19.1.6",
+        "@types/react-dom": "^19.1.5",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+      },
+      "devDependencies": {
+        "@vitejs/plugin-react": "^4.0.0",
+        "vite": "^5.0.0"
       }
     },
     "frontend/site": {
@@ -10264,6 +10293,10 @@
         "node": ">=6"
       }
     },
+    "node_modules/lead-reports": {
+      "resolved": "frontend/RealtorInterface/LeadReports",
+      "link": true
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -11807,6 +11840,10 @@
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/realtor-onboarding": {
+      "resolved": "frontend/RealtorInterface/Onboarding",
+      "link": true
     },
     "node_modules/redis": {
       "version": "4.7.1",


### PR DESCRIPTION
## Summary
- add Redis length accessor
- support retrieving lead reports
- implement report generation service with OpenAI caching
- expose `/reports/:phone` endpoint
- serve static LeadReports frontend
- create LeadReports React app and Docker image
- include LeadReports service in docker-compose

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848310aa4e8832e94048c90e3808f41