### PR TITLE
Switch Twilio messages to WhatsApp

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -6,6 +6,7 @@ SUPABASE_SERVICE_ROLE_KEY=
 # Twilio
 TWILIO_ACCOUNT_SID=
 TWILIO_AUTH_TOKEN=
+# WhatsApp-enabled Twilio phone number (e.g. +14155238886)
 TWILIO_PHONE_NUMBER=
 
 # Third-party APIs

--- a/backend/src/messenger/messenger.service.ts
+++ b/backend/src/messenger/messenger.service.ts
@@ -29,8 +29,8 @@ export class MessengerService {
     try {
       await this.twilio.messages.create({
         body: text,
-        to: phone,
-        from: this.from,
+        to: `whatsapp:${phone}`,
+        from: `whatsapp:${this.from}`,
       });
       await this.supabase.from('message_logs').insert({
         phone,
@@ -42,7 +42,7 @@ export class MessengerService {
         await this.conversation.store(phone, { role: 'assistant', content: text });
       }
     } catch (err) {
-      this.log.error('Failed to send SMS', err as Error);
+      this.log.error('Failed to send message', err as Error);
       await this.supabase.from('message_logs').insert({
         phone,
         message_type: 'text',

--- a/backend/src/scheduler/cron.ts
+++ b/backend/src/scheduler/cron.ts
@@ -36,8 +36,8 @@ export async function handler(): Promise<void> {
     try {
       await twilio.messages.create({
         body: row.message_text ?? '',
-        to: row.phone,
-        from: FROM,
+        to: `whatsapp:${row.phone}`,
+        from: `whatsapp:${FROM}`,
       });
       console.log(`Sent message ${row.id} to ${row.phone}`);
       await supabase

--- a/backend/src/scheduler/scheduler.service.ts
+++ b/backend/src/scheduler/scheduler.service.ts
@@ -96,8 +96,8 @@ export class SchedulerService implements OnModuleInit, OnModuleDestroy {
       try {
         await this.twilio.messages.create({
           body: row.message_text ?? '',
-          to: row.phone,
-          from: this.from,
+          to: `whatsapp:${row.phone}`,
+          from: `whatsapp:${this.from}`,
         });
         await this.client
           .from('scheduled_messages')

--- a/docs/UserTesting/survey-testing.md
+++ b/docs/UserTesting/survey-testing.md
@@ -29,7 +29,7 @@ curl -X POST http://134.199.198.237:3000/api/leads \
 
 ## Schedule a Follow‑up Message (optional)
 
-To replicate the reminder SMS that the survey normally triggers, call `POST /api/schedule` with the phone number, ISO timestamp and message text:
+To replicate the reminder WhatsApp message that the survey normally triggers, call `POST /api/schedule` with the phone number, ISO timestamp and message text:
 
 ```bash
 curl -X POST http://134.199.198.237:3000/api/schedule \

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -8,9 +8,9 @@ This page summarises the variables defined in `.env.example` and what they are u
 - `SUPABASE_SERVICE_ROLE_KEY` – service role key for privileged operations in Supabase.
 
 ## Twilio
-- `TWILIO_ACCOUNT_SID` – account identifier for sending SMS via Twilio.
+- `TWILIO_ACCOUNT_SID` – account identifier for sending WhatsApp messages via Twilio.
 - `TWILIO_AUTH_TOKEN` – authentication token used with the SID.
-- `TWILIO_PHONE_NUMBER` – phone number from which SMS are sent.
+- `TWILIO_PHONE_NUMBER` – WhatsApp-enabled phone number used to send messages.
 
 ## Third‑party APIs
 - `OPENAI_API_KEY` – key for generating AI responses via OpenAI.

--- a/docs/survey-flow.md
+++ b/docs/survey-flow.md
@@ -14,17 +14,17 @@ Once on the booking site two scenarios may occur:
 - **[2a\*] Immediate Booking** – if the user books a time within five minutes, a confirmation message is sent:
   > “Thank you for booking a meeting with {realtor_name} at {date} {time}. {realtor_name} will soon enter contact with you.”
   Sending additional messages does nothing.
-- **[2b\*] No Booking Yet** – if no booking is made within five minutes, the built-in cron job schedules a reminder SMS via the Scheduler service.
+- **[2b\*] No Booking Yet** – if no booking is made within five minutes, the built-in cron job schedules a reminder WhatsApp message via the Scheduler service.
 
 Each booking writes a Google Calendar event and stores its link and phone number in Supabase. When users reschedule, the site reads updated times from Google Calendar and confirms the change.
 
-## 3. SMS Tools ([1b\*] and [2b\*])
+## 3. Messaging Tools ([1b\*] and [2b\*])
 Users who remain in the messaging flow can interact via three commands:
 1. **Book** – schedule a date and time.
 2. **See availability** – list open time slots.
 3. **Stop** – opt out of future messages.
 
-The Messenger service receives incoming SMS through Twilio, generates a response using OpenAI, and sends the reply immediately.
+The Messenger service receives incoming WhatsApp messages through Twilio, generates a response using OpenAI, and sends the reply immediately.
 
 ## 4. Microservice Connections
 ```mermaid
@@ -35,7 +35,7 @@ flowchart TD
     Site -->|create event| Calendar
     Calendar -->|write link| Supabase
     Site -->|schedule reminder| Scheduler
-    Scheduler -->|send SMS| Messenger
+    Scheduler -->|send message| Messenger
     Messenger -->|reply| Twilio
 ```
 


### PR DESCRIPTION
## Summary
- send all Twilio messages via WhatsApp by prefixing `whatsapp:` in messenger service and schedulers
- document new WhatsApp behaviour in env vars and survey docs
- clarify follow‑up instructions in user testing doc
- note WhatsApp requirement in `.env.example`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68483674d028832e9a4977d79f45a445