### PR TITLE
Improve Twilio startup checks

### DIFF
--- a/backend/src/twilio/twilio.service.ts
+++ b/backend/src/twilio/twilio.service.ts
@@ -1,10 +1,11 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { Twilio } from 'twilio';
 
 @Injectable()
 export class TwilioService {
   private readonly client: Twilio;
   private readonly from: string;
+  private readonly log = new Logger('TwilioService');
 
   constructor() {
     this.client = new Twilio(
@@ -12,6 +13,9 @@ export class TwilioService {
       process.env.TWILIO_AUTH_TOKEN ?? '',
     );
     this.from = process.env.TWILIO_PHONE_NUMBER ?? '';
+    if (!this.from) {
+      this.log.error('TWILIO_PHONE_NUMBER environment variable is missing');
+    }
   }
 
   async sendWhatsApp(to: string, body: string): Promise<void> {

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -10,7 +10,7 @@ This page summarises the variables defined in `.env.example` and what they are u
 ## Twilio
 - `TWILIO_ACCOUNT_SID` – account identifier for sending WhatsApp messages via Twilio.
 - `TWILIO_AUTH_TOKEN` – authentication token used with the SID.
-- `TWILIO_PHONE_NUMBER` – WhatsApp-enabled phone number used to send messages.
+- `TWILIO_PHONE_NUMBER` – WhatsApp-enabled phone number used to send messages. The server logs an error during startup if this value is not provided.
 
 ## Third‑party APIs
 - `OPENAI_API_KEY` – key for generating AI responses via OpenAI.


### PR DESCRIPTION
## Summary
- log when `TWILIO_PHONE_NUMBER` isn't provided
- document the missing variable warning in the environment variable guide

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684845242d3c832ea2de22d3b1cb8ce5