### PR TITLE
Normalize phone numbers for survey leads

### DIFF
--- a/backend/src/leads/leads.service.ts
+++ b/backend/src/leads/leads.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { normalizePhone } from '../utils/phone';
 
 interface LeadInput {
   name: string;
@@ -65,8 +66,9 @@ export class LeadsService {
     const lastName = rest.join(' ');
     console.debug('[LeadsService] parsed name', { firstName, lastName });
 
+    const sanitizedPhone = normalizePhone(input.phone);
     const leadRecord = {
-      phone: input.phone,
+      phone: sanitizedPhone,
       realtor_id: realtorId,
       first_name: firstName,
       last_name: lastName,
@@ -105,10 +107,11 @@ export class LeadsService {
   }
 
   async findByPhone(phone: string) {
+    const sanitized = normalizePhone(phone);
     const { data } = await this.client
       .from('leads')
       .select('first_name,last_name,phone')
-      .eq('phone', phone)
+      .eq('phone', sanitized)
       .maybeSingle();
     const lead = data as {
       first_name: string;
@@ -161,12 +164,13 @@ export class LeadsService {
     realtorName: string;
     answers: { question: string; answer: string }[];
   } | null> {
+    const sanitized = normalizePhone(phone);
     const { data } = await this.client
       .from('leads')
       .select(
         `address,home_type,bedrooms,bathrooms,sqft,home_built,occupancy,sell_time,working_with_agent,looking_to_buy,realtor:realtor_id(f_name,e_name)`,
       )
-      .eq('phone', phone)
+      .eq('phone', sanitized)
       .maybeSingle();
     const lead =
       (data as {
@@ -225,12 +229,13 @@ export class LeadsService {
     address: string | null;
     answers: { question: string; answer: string }[];
   } | null> {
+    const sanitized = normalizePhone(phone);
     const { data } = await this.client
       .from('leads')
       .select(
         `first_name,last_name,phone,address,home_type,bedrooms,bathrooms,sqft,home_built,occupancy,sell_time,working_with_agent,looking_to_buy`,
       )
-      .eq('phone', phone)
+      .eq('phone', sanitized)
       .maybeSingle();
     const lead =
       (data as {

--- a/backend/src/utils/phone.ts
+++ b/backend/src/utils/phone.ts
@@ -1,0 +1,10 @@
+export function normalizePhone(phone: string): string {
+  const digits = phone.replace(/\D/g, '');
+  let cleaned = digits;
+  if (cleaned.length === 11 && cleaned.startsWith('1')) {
+    cleaned = cleaned.slice(1);
+  } else if (cleaned.length > 10) {
+    cleaned = cleaned.slice(cleaned.length - 10);
+  }
+  return '+1' + cleaned;
+}

--- a/frontend/survey/src/App.jsx
+++ b/frontend/survey/src/App.jsx
@@ -233,7 +233,8 @@ export default function App() {
 
       const formData = new FormData(form);
       const name = formData.get('fullName');
-      const phone = formData.get('phone');
+      const rawPhone = formData.get('phone');
+      const phone = '+1' + String(rawPhone).replace(/\D/g, '').slice(-10);
       const email = formData.get('email') || '';
       const zipcode = formData.get('zipcode') || '';
       const homeType = formData.get('homeType') || '';


### PR DESCRIPTION
## Summary
- add utility to normalize phone numbers to `+1XXXXXXXXXX`
- sanitize phone numbers in lead creation and lookup
- ensure survey submission sends normalized phone numbers

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848b5a740ac832ea1cc5afe20781ba1