### PR TITLE
Remove master-switch and update LeadReports docker path

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,22 @@ This repository contains a small NestJS backend and two React front ends used to
    ```bash
    npm run start:dev
    ```
-3. Build and preview the full stack:
+3. Build the project and start the services individually:
    ```bash
-   npm run master-switch
+   npm run build
+   npm run start:prod
+   ```
+   In other terminals preview each front end:
+   ```bash
+   npm --workspace frontend/site run preview -- --port 4173
+   npm --workspace frontend/survey run preview -- --port 4174
+   npm --workspace frontend/RealtorInterface/Onboarding run preview -- --port 4175
+   npm --workspace frontend/RealtorInterface/LeadReports run preview -- --port 4176
    ```
    - API: <http://localhost:3000>
    - Landing page: <http://localhost:4173>
    - Survey site: <http://localhost:4174>
+   - Lead reports: <http://localhost:4176/LeadReports>
 
 To work on either front end individually, run `npm run dev` inside its folder. See the [docs directory](docs/README.md) for environment variables, database schema and other guides.
 

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -18,13 +18,25 @@ This guide explains how to configure the project for local development and how t
    ```bash
    npm run start:dev
    ```
-4. Build and preview the full stack with one command:
+4. Build the project:
    ```bash
-   npm run master-switch
+   npm run build
+   ```
+   Start the backend with:
+   ```bash
+   npm run start:prod
+   ```
+   In separate terminals preview each front end:
+   ```bash
+   npm --workspace frontend/site run preview -- --port 4173
+   npm --workspace frontend/survey run preview -- --port 4174
+   npm --workspace frontend/RealtorInterface/Onboarding run preview -- --port 4175
+   npm --workspace frontend/RealtorInterface/LeadReports run preview -- --port 4176
    ```
    - API: <http://localhost:3000>
    - Landing page: <http://localhost:4173>
    - Survey site: <http://localhost:4174>
+   - Lead reports: <http://localhost:4176/LeadReports>
 
 ## Docker Compose
 

--- a/frontend/RealtorInterface/LeadReports/Dockerfile
+++ b/frontend/RealtorInterface/LeadReports/Dockerfile
@@ -5,6 +5,6 @@ RUN npm install && npm run build
 
 FROM nginx:alpine
 COPY frontend/RealtorInterface/LeadReports/nginx.conf /etc/nginx/conf.d/default.conf
-COPY --from=build /app/reports/dist /usr/share/nginx/html
+COPY --from=build /app/reports/dist /usr/share/nginx/html/LeadReports
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/RealtorInterface/LeadReports/nginx.conf
+++ b/frontend/RealtorInterface/LeadReports/nginx.conf
@@ -3,8 +3,8 @@ server {
     location /api/ {
         proxy_pass http://api:3000/api/;
     }
-    location / {
-        root /usr/share/nginx/html;
-        try_files $uri /index.html;
+    location /LeadReports/ {
+        alias /usr/share/nginx/html/LeadReports/;
+        try_files $uri $uri/ /LeadReports/index.html;
     }
 }

--- a/frontend/RealtorInterface/LeadReports/vite.config.js
+++ b/frontend/RealtorInterface/LeadReports/vite.config.js
@@ -1,12 +1,12 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
-export default defineConfig({
-  base: './',
+export default defineConfig(({ mode }) => ({
+  base: mode === 'production' ? '/LeadReports/' : './',
   plugins: [react()],
   server: {
     proxy: {
       '/api': 'http://localhost:3000',
     },
   },
-});
+}));

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "start:dev": "nest start --watch -c backend/nest-cli.json -p backend/tsconfig.build.json",
     "start:debug": "nest start --debug --watch -c backend/nest-cli.json -p backend/tsconfig.build.json",
     "start:prod": "node backend/dist/main",
-    "master-switch": "npm run build && npm --workspace frontend/site run build && npm --workspace frontend/survey run build && npm --workspace frontend/RealtorInterface/Onboarding run build && npx concurrently \"npm run start:prod\" \"npm --workspace frontend/site run preview -- --port 4173\" \"npm --workspace frontend/survey run preview -- --port 4174\" \"npm --workspace frontend/RealtorInterface/Onboarding run preview -- --port 4175\"",
     "lint": "eslint \"{backend/src,frontend,libs,backend/test}/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",


### PR DESCRIPTION
## Summary
- delete the `master-switch` script
- clarify manual preview steps in docs
- set `/LeadReports/` base path in LeadReports vite config
- update Dockerfile and nginx config for LeadReports

## Testing
- `npm install --ignore-scripts --no-audit --no-fund`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684976fce420832eb3a2fb5d20fc1f3c