### PR TITLE
Expose landing page ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,4 +45,5 @@ All services can be started with Docker:
 ```bash
 docker-compose up --build
 ```
-This brings up the API, both front ends and Redis using the same ports as above.
+This brings up the API, all front ends and Redis. The landing page will be
+available on ports 80 and 443, while the other sites use the ports listed above.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,8 @@ services:
     depends_on:
       - api
     ports:
-      - '4173:80'
+      - '80:80'
+      - '443:443'
   survey:
     build:
       context: .

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -50,4 +50,4 @@ scp /Users/peternyman/dev/Fon/Lead/backend/.env root@134.199.198.237:/home/Lead/
 ```
 
 
-Make sure your environment variables from `backend/.env` are available when starting the containers. When running through Docker Compose the services will be accessible at the same ports listed above and Redis will listen on `localhost:6379`.
+Make sure your environment variables from `backend/.env` are available when starting the containers. When running through Docker Compose the landing page listens on ports 80 and 443, while the other services keep the ports listed above. Redis will listen on `localhost:6379`.


### PR DESCRIPTION
## Summary
- expose site service on ports 80 and 443
- document the changed ports for Docker Compose

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6849dbcd7844832eac6be7fc225c6e7d