### PR TITLE
Add Nginx proxy docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,3 +10,4 @@ Guides and references for working with the Lead Management System.
 - [Testing the Survey with cURL](UserTesting/survey-testing.md)
 - [Sending Test Messages](UserTesting/message-testing.md)
 - [Open Questions](open-questions.md)
+- [Nginx Proxy Setup](nginx-proxy.md)

--- a/docs/doc-audit.md
+++ b/docs/doc-audit.md
@@ -19,6 +19,7 @@ Each markdown file in the repository has been tagged with a status:
 | docs/survey-flow.md | keep |
 | docs/UserTesting/message-testing.md | keep |
 | docs/UserTesting/survey-testing.md | keep |
+| docs/nginx-proxy.md | keep |
 | docs/site-migration-plan.md | delete |
 | docs/site.md | delete |
 | docs/user-data-site.md | delete |

--- a/docs/nginx-proxy.md
+++ b/docs/nginx-proxy.md
@@ -1,0 +1,71 @@
+# Nginx Reverse Proxy Setup
+
+This guide explains how to run an Nginx container that forwards traffic to all application services.
+
+## Overview
+
+The `docker-compose.yml` file defines a `proxy` service using the official `nginx:alpine` image. The container listens on ports 80 and 443, terminates TLS and proxies requests to the API and the front ends running on internal ports.
+
+```yaml
+proxy:
+  image: nginx:alpine
+  container_name: lead-proxy
+  ports:
+    - "80:80"
+    - "443:443"
+  volumes:
+    - ./proxy/conf.d:/etc/nginx/conf.d:ro
+    - /etc/letsencrypt/live/myrealvaluation.com:/etc/nginx/certs:ro
+  depends_on:
+    - site
+    - survey
+    - onboarding
+    - leadreports
+    - api
+```
+
+The virtual host files live in `proxy/conf.d`. A sample configuration forwards different URL paths to each service.
+
+```nginx
+# HTTP → HTTPS redirect
+server {
+    listen 80;
+    server_name myrealvaluation.com;
+    return 301 https://$host$request_uri;
+}
+
+# TLS termination + reverse-proxy
+server {
+    listen 443 ssl;
+    server_name myrealvaluation.com;
+
+    ssl_certificate     /etc/letsencrypt/live/myrealvaluation.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/myrealvaluation.com/privkey.pem;
+
+    location /          { proxy_pass http://site:80;        proxy_set_header Host $host; proxy_set_header X-Real-IP $remote_addr; }
+    location /survey/   { proxy_pass http://survey:80/;     proxy_set_header Host $host; proxy_set_header X-Real-IP $remote_addr; }
+    location /onboarding/ { proxy_pass http://onboarding:80/; proxy_set_header Host $host; proxy_set_header X-Real-IP $remote_addr; }
+    location /reports/  { proxy_pass http://leadreports:80/; proxy_set_header Host $host; proxy_set_header X-Real-IP $remote_addr; }
+    location /api/      { proxy_pass http://api:3000/;      proxy_set_header Host $host; proxy_set_header X-Real-IP $remote_addr; }
+}
+```
+
+The certificate paths above assume you have obtained TLS certificates (for example using Let's Encrypt) and mounted them into the container. Adjust the domain name and certificate locations to match your environment.
+
+## Running
+
+Start all services with Docker Compose:
+
+```bash
+docker-compose up --build
+```
+
+Once the containers are running, Nginx exposes ports 80 and 443 on the host. It routes requests to:
+
+- `/` → landing page container (`site`)
+- `/survey/` → survey container (`survey`)
+- `/onboarding/` → onboarding front end
+- `/reports/` → lead reports front end
+- `/api/` → NestJS backend
+
+With this setup a single domain serves the entire application stack over HTTPS.


### PR DESCRIPTION
## Summary
- document how to run the Nginx reverse proxy
- link new guide from documentation index
- note the file in doc-audit

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849f2df4958832e8b9979c71a8cb957