### PR TITLE
Fix double booking

### DIFF
--- a/backend/src/booking/booking.service.ts
+++ b/backend/src/booking/booking.service.ts
@@ -58,6 +58,14 @@ export class BookingService {
     const endIso = end.toISO();
     if (!startIso || !endIso) throw new Error('Invalid booking time');
 
+    const day = start.toISODate();
+    const openings = await this.calendar.getBookedSlots(
+      input.realtor_id,
+      day ?? input.booked_date,
+    );
+    if (openings.booked.includes(start.toFormat('HH:mm')))
+      throw new Error('Time slot already booked');
+
     await this.calendar.addEvent(input.realtor_id, {
       summary: `Meeting with ${input.full_name}`,
       description: `Phone: ${phone}`,

--- a/database/postgres.sql
+++ b/database/postgres.sql
@@ -129,6 +129,7 @@ create table public.bookings (
     created_at        timestamptz     default now(),
     updated_at        timestamptz     default now()
 );
+create unique index on public.bookings(realtor_id, appointment_time);
 
 
 /* 2-d Scheduled messages for future SMS */

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -40,13 +40,17 @@ Example data for local development is provided in [`database/seed.sql`](../datab
 - `sent_schedule_reminder`
 - `created_at`
 
-### Booked
-- `phone` – primary key
-- `full_name`
-- `appointment_time`
-- `meeting_link`
+### Bookings
+- `booking_id` – primary key
+- `phone` – references `Leads`
 - `realtor_id` – references `Realtor`
+- `appointment_time`
+- `google_calendar_id`
+- `google_event_id`
+- `status`
 - `created_at`
+- `updated_at`
+- unique `(realtor_id, appointment_time)` to prevent double booking
 
 ### Messages
 - `phone` – references `Leads`
@@ -91,8 +95,8 @@ The seed script inserts two sample leads and a booked appointment:
 INSERT INTO Leads (...)
     ('555-0001', 1, 'Eve', 'Example', '123 Main St', ...),
     ('555-0002', 2, 'John', 'Doe', '456 Oak Ave', ...);
-INSERT INTO Booked (phone, full_name, appointment_time, meeting_link, realtor_id)
-VALUES ('555-0001', 'Eve Example', NOW(), 'https://example.com/meet', 1);
+INSERT INTO Bookings (phone, realtor_id, appointment_time, google_calendar_id, google_event_id)
+VALUES ('555-0001', 1, NOW(), 'primary', 'abc123');
 ```
 See [`database/seed.sql`](../database/seed.sql) for the full statements.
 


### PR DESCRIPTION
## Summary
- prevent double booking by checking for existing appointments
- enforce unique appointment times for each realtor in DB
- document the bookings table and new uniqueness rule

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ad83dbb18832eb35cf18f64251af4