### PR TITLE
Fix booking table references for AI functions

### DIFF
--- a/backend/src/booking/booking.service.ts
+++ b/backend/src/booking/booking.service.ts
@@ -31,7 +31,7 @@ export class BookingService {
   async getExisting(phone: string) {
     const sanitized = normalizePhone(phone);
     const { data } = await this.supabase
-      .from('booked')
+      .from('bookings')
       .select('appointment_time')
       .eq('phone', sanitized)
       .maybeSingle();
@@ -75,7 +75,7 @@ export class BookingService {
       phone,
     });
 
-    await this.supabase.from('booked').upsert({
+    await this.supabase.from('bookings').upsert({
       phone,
       name: input.full_name,
       appointment_time: start.toISO(),

--- a/backend/src/calendar/calendar.service.ts
+++ b/backend/src/calendar/calendar.service.ts
@@ -156,7 +156,7 @@ export class CalendarService {
     const start = `${date}T00:00:00`;
     const end = `${date}T23:59:59`;
     const booked = await this.supabase.query(
-      `booked?realtor_id=eq.${realtorId}&appointment_time=gte.${start}&appointment_time=lte.${end}&select=appointment_time`,
+      `bookings?realtor_id=eq.${realtorId}&appointment_time=gte.${start}&appointment_time=lte.${end}&select=appointment_time`,
     );
     const bookedList = Array.isArray(booked)
       ? (booked as { appointment_time: string }[])


### PR DESCRIPTION
## Summary
- use `bookings` table in calendar and booking services

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ae55e390c832eadec8ae58305852a