### PR TITLE
Align URLs with new domain routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This repository contains a small NestJS backend and two React front ends used to
    - Landing page: <http://localhost:4173>
    - Start page: <http://localhost:4177>
    - Survey site: <http://localhost:4174>
-   - Lead reports: <http://localhost:4176/LeadReports>
+    - Lead reports: <http://localhost:4176/console/reports>
 
 To work on either front end individually, run `npm run dev` inside its folder. See the [docs directory](docs/README.md) for environment variables, database schema and other guides.
 

--- a/docs/nginx-proxy.md
+++ b/docs/nginx-proxy.md
@@ -42,10 +42,15 @@ server {
     ssl_certificate     /etc/letsencrypt/live/myrealvaluation.com/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/myrealvaluation.com/privkey.pem;
 
-    location /          { proxy_pass http://site:80;        proxy_set_header Host $host; proxy_set_header X-Real-IP $remote_addr; }
-    location /survey/   { proxy_pass http://survey:80/;     proxy_set_header Host $host; proxy_set_header X-Real-IP $remote_addr; }
+    location = /          { proxy_pass http://startpage:80/; proxy_set_header Host $host; proxy_set_header X-Real-IP $remote_addr; }
+    location /s/         { proxy_pass http://site:80/;       proxy_set_header Host $host; proxy_set_header X-Real-IP $remote_addr; }
+    location /           { proxy_pass http://site:80;        proxy_set_header Host $host; proxy_set_header X-Real-IP $remote_addr; }
+    location /survey     { proxy_pass http://survey:80;      proxy_set_header Host $host; proxy_set_header X-Real-IP $remote_addr; }
+    location /survey/    { proxy_pass http://survey:80/;     proxy_set_header Host $host; proxy_set_header X-Real-IP $remote_addr; }
+    location /onboarding { proxy_pass http://onboarding:80;  proxy_set_header Host $host; proxy_set_header X-Real-IP $remote_addr; }
     location /onboarding/ { proxy_pass http://onboarding:80/; proxy_set_header Host $host; proxy_set_header X-Real-IP $remote_addr; }
-    location /reports/  { proxy_pass http://leadreports:80/; proxy_set_header Host $host; proxy_set_header X-Real-IP $remote_addr; }
+    location /console/reports { proxy_pass http://leadreports:80/; proxy_set_header Host $host; proxy_set_header X-Real-IP $remote_addr; }
+    location /console/reports/ { proxy_pass http://leadreports:80/; proxy_set_header Host $host; proxy_set_header X-Real-IP $remote_addr; }
     location /api/      { proxy_pass http://api:3000/;      proxy_set_header Host $host; proxy_set_header X-Real-IP $remote_addr; }
 }
 ```
@@ -62,10 +67,11 @@ docker-compose up --build
 
 Once the containers are running, Nginx exposes ports 80 and 443 on the host. It routes requests to:
 
-- `/` → landing page container (`site`)
-- `/survey/` → survey container (`survey`)
-- `/onboarding/` → onboarding front end
-- `/reports/` → lead reports front end
+- `/` → marketing start page (`startpage`)
+- `/:uuid` or `/s/:uuid` → booking site (`site`)
+- `/survey` → survey container (`survey`)
+- `/onboarding` → onboarding front end
+- `/console/reports` → lead reports front end
 - `/api/` → NestJS backend
 
 With this setup a single domain serves the entire application stack over HTTPS.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -5,10 +5,10 @@ This short guide explains how to link a Google Calendar so that bookings created
 The admin dashboard exposes a **Link Google Calendar** button during the onboarding process. Clicking it will open the Google consent screen using the `/api/calendar/oauth/<realtorId>` endpoint. After granting access the backend receives a refresh token so future calendar calls work without additional prompts.
 
 1. Ensure the backend is running and accessible. The `GOOGLE_REDIRECT_URI` environment variable must point to
-   `http://myrealvaluation.com/api/calendar/oauth/callback` (or your deployed URL).
+   `https://www.myrealvaluation.com/api/calendar/oauth/callback` (or your deployed URL).
 2. Obtain your personal authorization link by calling:
    ```bash
-   curl http://myrealvaluation.com/api/calendar/oauth/<realtorId>
+   curl https://www.myrealvaluation.com/api/calendar/oauth/<realtorId>
    ```
    The response contains a `url` field. Open it in your browser.
 3. Grant access to the requested Google account and confirm the consent screen.

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -36,7 +36,7 @@ This guide explains how to configure the project for local development and how t
    - API: <http://localhost:3000>
    - Landing page: <http://localhost:4173>
    - Survey site: <http://localhost:4174>
-   - Lead reports: <http://localhost:4176/LeadReports>
+    - Lead reports: <http://localhost:4176/console/reports>
 
 ## Docker Compose
 

--- a/frontend/RealtorInterface/LeadReports/Dockerfile
+++ b/frontend/RealtorInterface/LeadReports/Dockerfile
@@ -5,6 +5,6 @@ RUN npm install && npm run build
 
 FROM nginx:alpine
 COPY frontend/RealtorInterface/LeadReports/nginx.conf /etc/nginx/conf.d/default.conf
-COPY --from=build /app/reports/dist /usr/share/nginx/html/LeadReports
+COPY --from=build /app/reports/dist /usr/share/nginx/html/console/reports
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/RealtorInterface/LeadReports/README.md
+++ b/frontend/RealtorInterface/LeadReports/README.md
@@ -1,6 +1,6 @@
 Help me create a Reports for easy accses to lead information, 
 
-each report should be accesed by a link which is url/LeadReports/:phone
+each report should be accessed at `https://www.myrealvaluation.com/console/reports/:phone`
 
 all information form the report should come from supabase.
 

--- a/frontend/RealtorInterface/LeadReports/nginx.conf
+++ b/frontend/RealtorInterface/LeadReports/nginx.conf
@@ -3,8 +3,8 @@ server {
     location /api/ {
         proxy_pass http://api:3000/api/;
     }
-    location /LeadReports/ {
-        alias /usr/share/nginx/html/LeadReports/;
-        try_files $uri $uri/ /LeadReports/index.html;
+    location /console/reports/ {
+        alias /usr/share/nginx/html/console/reports/;
+        try_files $uri $uri/ /console/reports/index.html;
     }
 }

--- a/frontend/RealtorInterface/LeadReports/vite.config.js
+++ b/frontend/RealtorInterface/LeadReports/vite.config.js
@@ -2,7 +2,7 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig(({ mode }) => ({
-  base: mode === 'production' ? '/LeadReports/' : './',
+  base: mode === 'production' ? '/console/reports/' : './',
   plugins: [react()],
   server: {
     proxy: {

--- a/frontend/StartPage/src/App.jsx
+++ b/frontend/StartPage/src/App.jsx
@@ -34,7 +34,7 @@ export default function App() {
                 <div className="hero-content">
                     <h1>Smarter Real Estate Leads, Powered by AI</h1>
                     <p>Connect with motivated sellers through the most intelligent and efficient lead generation platform built for realtors.</p>
-                    <a href="http://134.199.198.237:4175/" className="cta-button">Get Started – Realtor Sign-Up</a>
+                    <a href="/onboarding" className="cta-button">Get Started – Realtor Sign-Up</a>
                 </div>
             </div>
         </section>
@@ -112,7 +112,7 @@ export default function App() {
         <section className="final-cta">
             <div className="container">
                 <h2>Ready to grow your business with smarter leads?</h2>
-                <a href="http://134.199.198.237:4175/" className="cta-button">Get Started – Realtor Sign-Up</a>
+                <a href="/onboarding" className="cta-button">Get Started – Realtor Sign-Up</a>
             </div>
         </section>
     

--- a/proxy/conf.d/site.conf
+++ b/proxy/conf.d/site.conf
@@ -13,11 +13,22 @@ server {
     ssl_certificate     /etc/letsencrypt/live/myrealvaluation.com/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/myrealvaluation.com/privkey.pem;
 
-    location /          { proxy_pass http://site:80;        proxy_set_header Host $host; proxy_set_header X-Real-IP $remote_addr; }
-    location /survey/   { proxy_pass http://survey:80/;     proxy_set_header Host $host; proxy_set_header X-Real-IP $remote_addr; }
+    # Start page at root
+    location = /          { proxy_pass http://startpage:80/; proxy_set_header Host $host; proxy_set_header X-Real-IP $remote_addr; }
+
+    # Booking site under dynamic paths and /s/
+    location /s/         { proxy_pass http://site:80/;       proxy_set_header Host $host; proxy_set_header X-Real-IP $remote_addr; }
+    location /           { proxy_pass http://site:80;        proxy_set_header Host $host; proxy_set_header X-Real-IP $remote_addr; }
+
+    # Individual apps
+    location /survey     { proxy_pass http://survey:80;      proxy_set_header Host $host; proxy_set_header X-Real-IP $remote_addr; }
+    location /survey/    { proxy_pass http://survey:80/;     proxy_set_header Host $host; proxy_set_header X-Real-IP $remote_addr; }
+    location /onboarding { proxy_pass http://onboarding:80;  proxy_set_header Host $host; proxy_set_header X-Real-IP $remote_addr; }
     location /onboarding/ { proxy_pass http://onboarding:80/; proxy_set_header Host $host; proxy_set_header X-Real-IP $remote_addr; }
-    location /reports/  { proxy_pass http://leadreports:80/; proxy_set_header Host $host; proxy_set_header X-Real-IP $remote_addr; }
-    location /start/    { proxy_pass http://startpage:80/;   proxy_set_header Host $host; proxy_set_header X-Real-IP $remote_addr; }
+    location /console/reports { proxy_pass http://leadreports:80/; proxy_set_header Host $host; proxy_set_header X-Real-IP $remote_addr; }
+    location /console/reports/ { proxy_pass http://leadreports:80/; proxy_set_header Host $host; proxy_set_header X-Real-IP $remote_addr; }
+
+    # Backend API
     location /api/      { proxy_pass http://api:3000/;      proxy_set_header Host $host; proxy_set_header X-Real-IP $remote_addr; }
 }
 


### PR DESCRIPTION
## Summary
- update Nginx routes to point `/` at the StartPage and add `/console/reports`
- fix StartPage links to use `/onboarding`
- serve lead reports from `/console/reports`
- document new paths in README and docs
- update OAuth example URLs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852c9ae9d84832ea3e2fe968db142d4