### PR TITLE
Fix Onboarding Dockerfile build

### DIFF
--- a/frontend/RealtorInterface/Onboarding/Dockerfile
+++ b/frontend/RealtorInterface/Onboarding/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:20-alpine AS builder
 WORKDIR /app/onboarding
 COPY frontend/RealtorInterface/Onboarding ./
-RUN npm ci
+RUN npm install
 RUN npm run build
 
 FROM nginx:alpine


### PR DESCRIPTION
## Summary
- use `npm install` instead of `npm ci` when building Realtor onboarding frontend

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685306a442b4832e8dbaafa9de6d514e