### PR TITLE
Fix Nginx restart in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,5 +17,5 @@ jobs:
             cp deploy/host-nginx/myrealvaluation.conf /etc/nginx/sites-available/
             ln -sf /etc/nginx/sites-available/myrealvaluation.conf /etc/nginx/sites-enabled/
             nginx -t
-            systemctl reload nginx
+            systemctl restart nginx
 


### PR DESCRIPTION
## Summary
- restart Nginx instead of reloading it during deployment so the service starts even if not currently running

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853114c17a8832e8d66f23145acfaab