### PR TITLE
Fix SPA forwarding in Nginx

### DIFF
--- a/deploy/host-nginx/myrealvaluation.conf
+++ b/deploy/host-nginx/myrealvaluation.conf
@@ -36,13 +36,15 @@ server {
     }
 
     location /survey/ {
-        proxy_pass http://localhost:4174;
+        # Strip the `/survey` prefix so the SPA is served from its root
+        proxy_pass http://localhost:4174/;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
     }
 
     location /onboarding/ {
-        proxy_pass http://localhost:4175;
+        # Strip the `/onboarding` prefix to serve assets correctly
+        proxy_pass http://localhost:4175/;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
     }


### PR DESCRIPTION
## Summary
- update Nginx vhost so `/survey` and `/onboarding` strip the prefix

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685323b6f0cc832e927982c6d0d71e89