### PR TITLE
Fix onboarding asset paths

### DIFF
--- a/frontend/RealtorInterface/Onboarding/vite.config.js
+++ b/frontend/RealtorInterface/Onboarding/vite.config.js
@@ -2,7 +2,7 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
-  base: '/onboarding/',
+  base: './',
   plugins: [react()],
   server: {
     proxy: {


### PR DESCRIPTION
## Summary
- adjust `vite.config.js` so onboarding frontend builds with relative paths

## Testing
- `npm test`
- `npm --workspace frontend/RealtorInterface/Onboarding run build`
- `docker compose build onboarding` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6853251f32d8832eb6b2b996ae34c5c5