### PR TITLE
Fix onboarding/survey asset paths

### DIFF
--- a/frontend/RealtorInterface/Onboarding/Dockerfile
+++ b/frontend/RealtorInterface/Onboarding/Dockerfile
@@ -6,6 +6,7 @@ RUN npm run build
 
 FROM nginx:alpine
 COPY frontend/RealtorInterface/Onboarding/nginx.conf /etc/nginx/conf.d/default.conf
-COPY --from=builder /app/onboarding/dist /usr/share/nginx/html
+RUN mkdir -p /usr/share/nginx/html/onboarding
+COPY --from=builder /app/onboarding/dist /usr/share/nginx/html/onboarding
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/survey/Dockerfile
+++ b/frontend/survey/Dockerfile
@@ -5,6 +5,7 @@ RUN npm install && npm run build
 
 FROM nginx:alpine
 COPY frontend/survey/nginx.conf /etc/nginx/conf.d/default.conf
-COPY --from=build /app/survey/dist /usr/share/nginx/html
+RUN mkdir -p /usr/share/nginx/html/survey
+COPY --from=build /app/survey/dist /usr/share/nginx/html/survey
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Summary
- serve built onboarding app from `/onboarding` folder
- serve built survey app from `/survey` folder

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685323b6f0cc832e927982c6d0d71e89