### PR TITLE
Update survey Docker image paths

### DIFF
--- a/frontend/survey/Dockerfile
+++ b/frontend/survey/Dockerfile
@@ -5,7 +5,6 @@ RUN npm install && npm run build
 
 FROM nginx:alpine
 COPY frontend/survey/nginx.conf /etc/nginx/conf.d/default.conf
-RUN mkdir -p /usr/share/nginx/html/survey
-COPY --from=build /app/survey/dist /usr/share/nginx/html/survey
+COPY --from=build /app/survey/dist /usr/share/nginx/html
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/survey/nginx.conf
+++ b/frontend/survey/nginx.conf
@@ -5,9 +5,8 @@ server {
         proxy_pass http://api:3000/api/;
     }
 
-    # Serve the survey SPA from /survey/
-    location /survey/ {
-        alias /usr/share/nginx/html/survey/;
-        try_files $uri $uri/ /survey/index.html;
+    location / {
+        root /usr/share/nginx/html;
+        try_files $uri /index.html;
     }
 }


### PR DESCRIPTION
## Summary
- simplify the survey Dockerfile
- serve the survey SPA from the nginx root

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68532c2e3560832e8bffae7ccc497a28