### PR TITLE
Update docs with production URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@ This repository contains a small NestJS backend and two React front ends used to
    npm --workspace frontend/RealtorInterface/Onboarding run preview -- --port 4175
    npm --workspace frontend/RealtorInterface/LeadReports run preview -- --port 4176
    ```
-   - API: <http://localhost:3000>
-   - Start page: <http://localhost:4173>
-   - Landing page: <http://localhost:4177> (hosted at `/s`)
-   - Survey site: <http://localhost:4174>
-    - Lead reports: <http://localhost:4176/console/reports>
+  - API: <https://www.myrealvalaution.com/api>
+  - Start page: <https://www.myrealvalaution.com/>
+  - Landing page: <https://www.myrealvalaution.com/s> (hosted at `/s`)
+  - Survey site: <https://www.myrealvalaution.com/survey>
+   - Lead reports: <https://www.myrealvalaution.com/console/reports>
 
 To work on either front end individually, run `npm run dev` inside its folder. See the [docs directory](docs/README.md) for environment variables, database schema and other guides.
 
@@ -51,7 +51,7 @@ This brings up the API, both front ends and Redis using the same ports as above.
 
 ### Deployment (host Nginx)
 Ubuntu’s built-in Nginx now owns ports **80/443**. All Docker services expose
-high ports on `localhost`; the vhost file
+high ports on `https://www.myrealvalaution.com/*`; the vhost file
 `deploy/host-nginx/myrealvaluation.conf` maps paths to those ports.
 
 ```bash
@@ -68,4 +68,3 @@ If you see “address already in use,” stop any legacy proxy containers:
 ```bash
 docker rm -f lead-proxy || true
 ```
-.

--- a/docs/UserTesting/message-testing.md
+++ b/docs/UserTesting/message-testing.md
@@ -4,7 +4,7 @@ This guide explains how to manually trigger the messaging flow using `curl`.
 It can be used to verify Twilio integration and the AI assistant's response.
 
 ## Prerequisites
-- The backend server must be running. By default it listens on `http://localhost:3000`.
+- The backend server must be running. By default it listens on `https://www.myrealvalaution.com/api`.
 - Environment variables for Twilio and Supabase need to be configured in `backend/.env`.
 
 ## Example Request

--- a/docs/UserTesting/survey-testing.md
+++ b/docs/UserTesting/survey-testing.md
@@ -1,6 +1,6 @@
 # Testing the Survey with cURL
 
-The survey front‑end normally posts answers to the Nest backend at `http://localhost:3000/api`. For quick testing you can mimic this step without a browser by sending the JSON payloads directly.
+The survey front‑end normally posts answers to the Nest backend at `https://www.myrealvalaution.com/api`. For quick testing you can mimic this step without a browser by sending the JSON payloads directly.
 
 ## Create a Lead
 

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -34,11 +34,11 @@ This guide explains how to configure the project for local development and how t
    npm --workspace frontend/RealtorInterface/Onboarding run preview -- --port 4175
    npm --workspace frontend/RealtorInterface/LeadReports run preview -- --port 4176
    ```
-   - API: <http://localhost:3000>
-   - Start page: <http://localhost:4173>
-   - Landing page: <http://localhost:4177> (hosted at `/s`)
-   - Survey site: <http://localhost:4174>
-    - Lead reports: <http://localhost:4176/console/reports>
+   - API: <https://www.myrealvalaution.com/api>
+   - Start page: <https://www.myrealvalaution.com/>
+   - Landing page: <https://www.myrealvalaution.com/s> (hosted at `/s`)
+   - Survey site: <https://www.myrealvalaution.com/survey>
+    - Lead reports: <https://www.myrealvalaution.com/console/reports>
 
 ## Docker Compose
 
@@ -52,4 +52,4 @@ scp /Users/peternyman/dev/Fon/Lead/backend/.env root@134.199.198.237:/home/Lead/
 ```
 
 
-Make sure your environment variables from `backend/.env` are available when starting the containers. When running through Docker Compose the services will be accessible at the same ports listed above and Redis will listen on `localhost:6379`.
+Make sure your environment variables from `backend/.env` are available when starting the containers. When running through Docker Compose the services will be accessible at the same ports listed above and Redis will listen on `https://www.myrealvalaution.com:6379`.


### PR DESCRIPTION
## Summary
- update README to use https://www.myrealvalaution.com
- update docs with production domain instead of localhost

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68532f247cd8832ebf51673b7655c878