### PR TITLE
Fix SPA path

### DIFF
--- a/frontend/RealtorInterface/LeadReports/Dockerfile
+++ b/frontend/RealtorInterface/LeadReports/Dockerfile
@@ -5,6 +5,6 @@ RUN npm install && npm run build
 
 FROM nginx:alpine
 COPY frontend/RealtorInterface/LeadReports/nginx.conf /etc/nginx/conf.d/default.conf
-COPY --from=build /app/reports/dist /usr/share/nginx/html/console/reports
+COPY --from=build /app/reports/dist /usr/share/nginx/html
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/RealtorInterface/LeadReports/nginx.conf
+++ b/frontend/RealtorInterface/LeadReports/nginx.conf
@@ -3,8 +3,8 @@ server {
     location /api/ {
         proxy_pass http://api:3000/api/;
     }
-    location /console/reports/ {
-        alias /usr/share/nginx/html/console/reports/;
-        try_files $uri $uri/ /console/reports/index.html;
+    location / {
+        root /usr/share/nginx/html;
+        try_files $uri $uri/ /index.html;
     }
 }

--- a/frontend/RealtorInterface/LeadReports/vite.config.js
+++ b/frontend/RealtorInterface/LeadReports/vite.config.js
@@ -2,7 +2,7 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig(({ mode }) => ({
-  base: mode === 'production' ? '/console/reports/' : './',
+  base: mode === 'production' ? '/' : './',
   plugins: [react()],
   server: {
     proxy: {


### PR DESCRIPTION
## Summary
- copy LeadReports build output directly to the nginx root
- serve build using generic location block
- adjust Vite config to use root base path

## Testing
- `npm test`
- `curl -I http://localhost:$PORT/assets/index-BrC2C5bi.js`

------
https://chatgpt.com/codex/tasks/task_e_68533b1c73d8832e9fa1e51446341430