### PR TITLE
Fix onboarding nginx root

### DIFF
--- a/frontend/RealtorInterface/Onboarding/nginx.conf
+++ b/frontend/RealtorInterface/Onboarding/nginx.conf
@@ -4,7 +4,7 @@ server {
         proxy_pass http://api:3000/api/;
     }
     location / {
-        root /usr/share/nginx/html;
+        root /usr/share/nginx/html/onboarding;
         try_files $uri $uri/ /index.html;
     }
 }


### PR DESCRIPTION
## Summary
- point Nginx root at the onboarding folder

## Testing
- `npm run build` within `frontend/RealtorInterface/Onboarding`
- `python3 -m http.server 8080 --directory /tmp/nginx-root`
- `curl -I http://localhost:8080/onboarding/`

------
https://chatgpt.com/codex/tasks/task_e_68533b269efc832e824079b2a8fbf043