### PR TITLE
Add /survey redirect in Nginx config

### DIFF
--- a/deploy/host-nginx/myrealvaluation.conf
+++ b/deploy/host-nginx/myrealvaluation.conf
@@ -35,6 +35,10 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
     }
 
+    location = /survey {
+        return 301 /survey/;
+    }
+
     location /survey/ {
         proxy_pass http://localhost:4174/;
         proxy_set_header Host $host;


### PR DESCRIPTION
## Summary
- ensure `/survey` redirects to `/survey/` before the survey SPA location block

## Testing
- `npm test`
- `nginx -t` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68533bd1c2e4832e926a18fd900192ab