### PR TITLE
Adjust onboarding paths without console prefix

### DIFF
--- a/frontend/RealtorInterface/Onboarding/Dockerfile
+++ b/frontend/RealtorInterface/Onboarding/Dockerfile
@@ -6,6 +6,6 @@ RUN npm run build
 
 FROM nginx:alpine
 COPY frontend/RealtorInterface/Onboarding/nginx.conf /etc/nginx/conf.d/default.conf
-COPY --from=builder /app/onboarding/dist /usr/share/nginx/html
+COPY --from=builder /app/onboarding/dist /usr/share/nginx/html/onboarding
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/RealtorInterface/Onboarding/nginx.conf
+++ b/frontend/RealtorInterface/Onboarding/nginx.conf
@@ -3,8 +3,8 @@ server {
     location /api/ {
         proxy_pass http://api:3000/api/;
     }
-    location / {
-        root /usr/share/nginx/html/onboarding;
-        try_files $uri $uri/ /index.html;
+    location /onboarding/ {
+        alias /usr/share/nginx/html/onboarding/;
+        try_files $uri $uri/ /onboarding/index.html;
     }
 }

--- a/frontend/RealtorInterface/Onboarding/vite.config.js
+++ b/frontend/RealtorInterface/Onboarding/vite.config.js
@@ -1,12 +1,12 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
-export default defineConfig({
-  base: '/onboarding/',
+export default defineConfig(({ mode }) => ({
+  base: mode === 'production' ? '/onboarding/' : './',
   plugins: [react()],
   server: {
     proxy: {
       '/api': 'http://localhost:3000',
     },
   },
-});
+}));


### PR DESCRIPTION
## Summary
- copy onboarding build to `/usr/share/nginx/html/onboarding`
- serve onboarding SPA from `/onboarding/` via nginx alias
- update Vite config to use `/onboarding/` in production

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68533f56cc64832eae9a5310eee27402