### PR TITLE
Fix consent validation

### DIFF
--- a/frontend/survey/src/App.jsx
+++ b/frontend/survey/src/App.jsx
@@ -157,9 +157,12 @@ export default function App() {
       if (currentQuestionId === 'contactInfo') {
         const requiredFields =
           currentQuestion.querySelectorAll('input[required]');
-        return Array.from(requiredFields).every(
-          (field) => field.value.trim() !== '',
-        );
+        return Array.from(requiredFields).every((field) => {
+          if (field.type === 'checkbox') {
+            return field.checked;
+          }
+          return field.value.trim() !== '';
+        });
       }
 
       const radioChecked = currentQuestion.querySelector(

--- a/frontend/survey/src/markup.js
+++ b/frontend/survey/src/markup.js
@@ -289,7 +289,7 @@ export const surveyMarkup = `
                     <div class="consent-field">
                     <label style="display:flex;align-items:flex-start;gap:8px;">
                         <input type="checkbox" name="consent" required style="margin-top:4px;">
-                        <span>I agree to receive marketing text messages from My Real Evaluation at the number I provided. These may be sent using automated technology, and my consent is not required to make a purchase. Message &amp; data rates may apply. I can opt out at any time by replying STOP.</span>
+                        <span><span class="required">*</span>&nbsp;I agree to receive marketing text messages from My Real Evaluation at the number I provided. These may be sent using automated technology, and my consent is not required to make a purchase. Message &amp; data rates may apply. I can opt out at any time by replying STOP.</span>
                     </label>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- require checkbox fields in contact step
- mark consent text as required visually

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68543da761d4832eb84829b41a5c9e79