### PR TITLE
load supabase env for frontend

### DIFF
--- a/frontend/RealtorInterface/Console/package.json
+++ b/frontend/RealtorInterface/Console/package.json
@@ -14,6 +14,7 @@
     "lucide-react": "^0.518.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "dotenv": "^16.5.0",
     "react-router-dom": "^7.6.2"
   },
   "devDependencies": {

--- a/frontend/RealtorInterface/Console/vite.config.js
+++ b/frontend/RealtorInterface/Console/vite.config.js
@@ -1,5 +1,19 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { config } from 'dotenv';
+import { resolve } from 'path';
+
+// Load backend environment so Supabase credentials are available during build
+// The config file resides three directories below the repo root
+config({ path: resolve(__dirname, '../../../backend/.env') });
+
+// Expose SUPABASE_* variables as VITE_* for the client bundle
+if (process.env.SUPABASE_URL) {
+  process.env.VITE_SUPABASE_URL = process.env.SUPABASE_URL;
+}
+if (process.env.SUPABASE_ANON_KEY) {
+  process.env.VITE_SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY;
+}
 
 export default defineConfig(({ mode }) => ({
   base: mode === 'production' ? '/console/' : './',

--- a/frontend/RealtorInterface/Onboarding/package.json
+++ b/frontend/RealtorInterface/Onboarding/package.json
@@ -13,7 +13,8 @@
     "@types/react-dom": "^19.1.5",
     "lucide-react": "^0.514.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "dotenv": "^16.5.0"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.0",

--- a/frontend/RealtorInterface/Onboarding/vite.config.js
+++ b/frontend/RealtorInterface/Onboarding/vite.config.js
@@ -1,5 +1,19 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { config } from 'dotenv';
+import { resolve } from 'path';
+
+// Load backend environment so Supabase credentials are available during build
+// The config file resides three directories below the repo root
+config({ path: resolve(__dirname, '../../../backend/.env') });
+
+// Expose SUPABASE_* variables as VITE_* for the client bundle
+if (process.env.SUPABASE_URL) {
+  process.env.VITE_SUPABASE_URL = process.env.SUPABASE_URL;
+}
+if (process.env.SUPABASE_ANON_KEY) {
+  process.env.VITE_SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY;
+}
 
 export default defineConfig(({ mode }) => ({
   base: mode === 'production' ? '/onboarding/' : './',


### PR DESCRIPTION
## Summary
- load backend `.env` file in Realtor frontends
- expose Supabase variables to vite via `VITE_` prefix
- install `dotenv` for Realtor frontends

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68544fcb0d6c832e9feef0de41c03838