### PR TITLE
Fix docker env handling

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
       dockerfile: backend/Dockerfile
     environment:
       REDIS_URL: redis://redis:6379
+    env_file:
+      - backend/.env
     depends_on:
       - redis
     ports:
@@ -51,6 +53,9 @@ services:
     build:
       context: .
       dockerfile: frontend/RealtorInterface/Onboarding/Dockerfile
+      args:
+        VITE_SUPABASE_URL: ${SUPABASE_URL}
+        VITE_SUPABASE_ANON_KEY: ${SUPABASE_ANON_KEY}
     depends_on:
       - api
     ports:
@@ -60,6 +65,9 @@ services:
     build:
       context: .
       dockerfile: frontend/RealtorInterface/Console/Dockerfile
+      args:
+        VITE_SUPABASE_URL: ${SUPABASE_URL}
+        VITE_SUPABASE_ANON_KEY: ${SUPABASE_ANON_KEY}
     depends_on:
       - api
     ports:

--- a/frontend/RealtorInterface/Console/Dockerfile
+++ b/frontend/RealtorInterface/Console/Dockerfile
@@ -1,6 +1,8 @@
 FROM node:20-alpine AS build
 WORKDIR /app/console
 COPY frontend/RealtorInterface/Console ./
+# include environment variables for Supabase during the build
+COPY backend/.env ./.env
 RUN npm install && npm run build
 
 FROM nginx:alpine

--- a/frontend/RealtorInterface/Onboarding/Dockerfile
+++ b/frontend/RealtorInterface/Onboarding/Dockerfile
@@ -1,6 +1,8 @@
 FROM node:20-alpine AS builder
 WORKDIR /app/onboarding
 COPY frontend/RealtorInterface/Onboarding ./
+# bring in backend environment variables so Vite can read them
+COPY backend/.env ./.env
 RUN npm install
 RUN npm run build
 


### PR DESCRIPTION
## Summary
- include `backend/.env` when building frontend containers
- pass `backend/.env` to the api container and forward Supabase vars for SPA builds

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685456d0201c832e86527a5d49244dd2