### PR TITLE
Ensure Docker containers use backend .env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
     build:
       context: .
       dockerfile: backend/Dockerfile
+    env_file:
+      - backend/.env
     environment:
       REDIS_URL: redis://redis:6379
     depends_on:
@@ -24,6 +26,8 @@ services:
     build:
       context: .
       dockerfile: frontend/StartPage/Dockerfile
+    env_file:
+      - backend/.env
     depends_on:
       - api
     ports:
@@ -33,6 +37,8 @@ services:
     build:
       context: .
       dockerfile: frontend/site/Dockerfile
+    env_file:
+      - backend/.env
     depends_on:
       - api
     ports:
@@ -42,6 +48,8 @@ services:
     build:
       context: .
       dockerfile: frontend/survey/Dockerfile
+    env_file:
+      - backend/.env
     depends_on:
       - api
     ports:
@@ -51,6 +59,11 @@ services:
     build:
       context: .
       dockerfile: frontend/RealtorInterface/Onboarding/Dockerfile
+      args:
+        SUPABASE_URL: ${SUPABASE_URL}
+        SUPABASE_ANON_KEY: ${SUPABASE_ANON_KEY}
+    env_file:
+      - backend/.env
     depends_on:
       - api
     ports:
@@ -60,6 +73,11 @@ services:
     build:
       context: .
       dockerfile: frontend/RealtorInterface/Console/Dockerfile
+      args:
+        SUPABASE_URL: ${SUPABASE_URL}
+        SUPABASE_ANON_KEY: ${SUPABASE_ANON_KEY}
+    env_file:
+      - backend/.env
     depends_on:
       - api
     ports:

--- a/frontend/RealtorInterface/Console/Dockerfile
+++ b/frontend/RealtorInterface/Console/Dockerfile
@@ -1,6 +1,15 @@
 FROM node:20-alpine AS build
 WORKDIR /app/console
 COPY frontend/RealtorInterface/Console ./
+
+# Inject Supabase credentials at build time so Vite can replace them in the
+# bundled assets. The values are provided via build arguments which are
+# populated by Docker Compose from `backend/.env`.
+ARG SUPABASE_URL
+ARG SUPABASE_ANON_KEY
+ENV VITE_SUPABASE_URL=$SUPABASE_URL
+ENV VITE_SUPABASE_ANON_KEY=$SUPABASE_ANON_KEY
+
 RUN npm install && npm run build
 
 FROM nginx:alpine

--- a/frontend/RealtorInterface/Onboarding/Dockerfile
+++ b/frontend/RealtorInterface/Onboarding/Dockerfile
@@ -1,6 +1,14 @@
 FROM node:20-alpine AS builder
 WORKDIR /app/onboarding
 COPY frontend/RealtorInterface/Onboarding ./
+
+# Supabase credentials are required during the build so the environment
+# variables are inlined in the generated JavaScript.
+ARG SUPABASE_URL
+ARG SUPABASE_ANON_KEY
+ENV VITE_SUPABASE_URL=$SUPABASE_URL
+ENV VITE_SUPABASE_ANON_KEY=$SUPABASE_ANON_KEY
+
 RUN npm install
 RUN npm run build
 


### PR DESCRIPTION
## Summary
- expose backend env vars to api container
- pass Supabase env vars to Console and Onboarding builds
- make Compose share the env file with all frontend services

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685456d0201c832e86527a5d49244dd2