### PR TITLE
Refactor realtor schema and onboarding

### DIFF
--- a/backend/src/agentLogic/agent.service.ts
+++ b/backend/src/agentLogic/agent.service.ts
@@ -85,7 +85,7 @@ export class AgentService {
         case 'list_available_times':
           if (isAvailArgs(args)) {
             const { realtor_id, date } = args as {
-              realtor_id: number;
+              realtor_id: string;
               date: string;
             };
             const booked = await this.calendar.getBookedSlots(realtor_id, date);
@@ -142,7 +142,7 @@ function isBookArgs(args: unknown): args is BookingInput {
 
 function isAvailArgs(
   args: unknown,
-): args is { realtor_id: number; date: string } {
+): args is { realtor_id: string; date: string } {
   return (
     typeof args === 'object' &&
     args !== null &&

--- a/backend/src/booking/booking.service.ts
+++ b/backend/src/booking/booking.service.ts
@@ -11,7 +11,7 @@ export interface BookingInput {
   booked_date: string; // YYYY-MM-DD
   booked_time: string; // HH:mm
   time_zone: string;
-  realtor_id: number;
+  realtor_id: string;
 }
 
 @Injectable()

--- a/backend/src/calendar/calendar.controller.ts
+++ b/backend/src/calendar/calendar.controller.ts
@@ -24,25 +24,25 @@ export class CalendarController {
     @Query('state') state: string,
     @Res() res: Response,
   ) {
-    const realtorId = Number(state);
+    const realtorId = state;
     await this.calendar.handleOAuthCallback(code, realtorId);
     return res.redirect('/realtor');
   }
 
   @Get('oauth/:realtorId')
-  getAuthUrl(@Param('realtorId') realtorId: number) {
+  getAuthUrl(@Param('realtorId') realtorId: string) {
     return { url: this.calendar.generateAuthUrl(realtorId) };
   }
 
   @Post(':realtorId/events')
   @HttpCode(201)
-  addEvent(@Param('realtorId') realtorId: number, @Body() body: EventInput) {
+  addEvent(@Param('realtorId') realtorId: string, @Body() body: EventInput) {
     return this.calendar.addEvent(realtorId, body);
   }
 
   @Patch(':realtorId/events/:eventId')
   updateEvent(
-    @Param('realtorId') realtorId: number,
+    @Param('realtorId') realtorId: string,
     @Param('eventId') eventId: string,
     @Body() body: Partial<EventInput> & { calendarId: string },
   ) {
@@ -53,7 +53,7 @@ export class CalendarController {
   @Delete(':realtorId/events/:eventId')
   @HttpCode(204)
   removeEvent(
-    @Param('realtorId') realtorId: number,
+    @Param('realtorId') realtorId: string,
     @Param('eventId') eventId: string,
     @Body('calendarId') calendarId: string,
   ) {
@@ -62,14 +62,14 @@ export class CalendarController {
 
   @Get(':realtorId/booked')
   getBooked(
-    @Param('realtorId') realtorId: number,
+    @Param('realtorId') realtorId: string,
     @Query('date') date: string,
   ) {
     return this.calendar.getBookedSlots(realtorId, date);
   }
 
   @Get(':realtorId/openings')
-  getOpen(@Param('realtorId') realtorId: number, @Query('date') date: string) {
+  getOpen(@Param('realtorId') realtorId: string, @Query('date') date: string) {
     return this.calendar.getOpenSlots(realtorId, date);
   }
 }

--- a/backend/src/leads/leads.service.ts
+++ b/backend/src/leads/leads.service.ts
@@ -52,7 +52,7 @@ export class LeadsService {
       throw realtorErr;
     }
 
-    const realtorId = (data as { realtor_id: number } | null)?.realtor_id;
+    const realtorId = (data as { realtor_id: string } | null)?.realtor_id;
     console.debug('[LeadsService] realtorId', realtorId);
 
     if (!realtorId) {
@@ -142,7 +142,7 @@ export class LeadsService {
       throw error;
     }
     const realtor = data as {
-      realtor_id: number;
+      realtor_id: string;
       f_name: string;
       e_name: string;
       video_url: string;

--- a/backend/src/realtor/dto/create-realtor.dto.ts
+++ b/backend/src/realtor/dto/create-realtor.dto.ts
@@ -1,16 +1,11 @@
-/* eslint-disable @typescript-eslint/no-unsafe-call */
-import { IsEmail, IsNotEmpty, IsString } from 'class-validator';
+import { IsNotEmpty, IsString, IsUUID } from 'class-validator';
 
 export class CreateRealtorDto {
   @IsString()
   @IsNotEmpty()
   name!: string;
 
-  @IsEmail()
+  @IsUUID()
   @IsNotEmpty()
-  email!: string;
-
-  @IsString()
-  @IsNotEmpty()
-  phone!: string;
+  userId!: string;
 }

--- a/backend/src/realtor/realtor.service.ts
+++ b/backend/src/realtor/realtor.service.ts
@@ -18,14 +18,13 @@ export class RealtorService {
     const { data, error } = await this.client
       .from('realtor')
       .insert({
+        realtor_id: input.userId,
         f_name: first,
         e_name: last,
-        email: input.email,
-        phone: input.phone,
       })
       .select('uuid,realtor_id')
       .single();
     if (error) throw error;
-    return data as { uuid: string; realtor_id: number };
+    return data as { uuid: string; realtor_id: string };
   }
 }

--- a/backend/src/scheduler/scheduler.service.ts
+++ b/backend/src/scheduler/scheduler.service.ts
@@ -43,7 +43,7 @@ export class SchedulerService implements OnModuleInit, OnModuleDestroy {
       .maybeSingle();
 
     if (error) throw error;
-    const realtorId = (lead as { realtor_id: number } | null)?.realtor_id;
+    const realtorId = (lead as { realtor_id: string } | null)?.realtor_id;
     if (!realtorId) throw new Error('Invalid phone number');
 
     await this.client.from('scheduled_messages').insert({

--- a/backend/src/supabase/supabase.service.ts
+++ b/backend/src/supabase/supabase.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
 interface GoogleCredentials {
-  realtor_id: number;
+  realtor_id: string;
   access_token: string;
   refresh_token: string;
   token_expires: string;
@@ -20,7 +20,7 @@ export class SupabaseService {
     } as Record<string, string>;
   }
 
-  async getCredentials(realtorId: number): Promise<GoogleCredentials | null> {
+  async getCredentials(realtorId: string): Promise<GoogleCredentials | null> {
     const res = await fetch(
       `${this.baseUrl}/google_credentials?realtor_id=eq.${realtorId}&select=*`,
       { headers: this.headers },
@@ -30,7 +30,7 @@ export class SupabaseService {
   }
 
   async updateCredentials(
-    realtorId: number,
+    realtorId: string,
     token: { access_token: string; expires_in: number },
   ): Promise<void> {
     const expires = new Date(
@@ -50,7 +50,7 @@ export class SupabaseService {
   }
 
   async insertCredentials(
-    realtorId: number,
+    realtorId: string,
     token: { access_token: string; refresh_token: string; expires_in: number },
   ): Promise<void> {
     const expires = new Date(
@@ -69,7 +69,7 @@ export class SupabaseService {
   }
 
   async upsertEvent(
-    realtorId: number,
+    realtorId: string,
     googleEventId: string,
     payload: Record<string, unknown>,
   ): Promise<void> {

--- a/database/postgres.sql
+++ b/database/postgres.sql
@@ -77,15 +77,13 @@ create type booking_status_t as enum ('pending','confirmed','canceled');
 
 /* 2-a  Realtors */
 create table public.realtor (
-    realtor_id   bigserial primary key,
+    realtor_id   uuid primary key references auth.users(id),
     uuid         uuid       not null unique default gen_random_uuid(),
-    phone        varchar(50)  not null,
     f_name       varchar(125) not null,
     e_name       varchar(125) not null,
     video_url    varchar(600),
-    email        varchar(255),
     website_url  varchar(600),
-    -- time_zone 
+    -- time_zone
     created_at   timestamptz default now()
 );
 
@@ -94,7 +92,7 @@ create index on public.realtor(uuid);
 /* 2-b  Leads */
 create table public.leads (
     phone                varchar(50) primary key,
-    realtor_id           bigint      not null references public.realtor(realtor_id) on delete cascade,
+    realtor_id           uuid      not null references public.realtor(realtor_id) on delete cascade,
     first_name           varchar(127),
     last_name            varchar(127),
     email                varchar(127),
@@ -116,13 +114,13 @@ create table public.leads (
 
 alter table public.leads enable row level security;
 create policy "realtor leads" on public.leads for select
-  using (realtor_id = (auth.jwt() ->> 'realtorId')::bigint);
+  using (realtor_id = (auth.jwt() ->> 'realtorId')::uuid);
 
 /* 2-c  Booked calls / appointments */
 create table public.bookings (
     booking_id        bigserial primary key,
     phone           varchar(50) not null references public.leads(phone) on delete cascade,
-    realtor_id        bigint       not null references public.realtor(realtor_id) on delete cascade,
+    realtor_id        uuid       not null references public.realtor(realtor_id) on delete cascade,
 
     appointment_time  timestamptz  not null,
     google_calendar_id varchar(256) not null,
@@ -139,7 +137,7 @@ create unique index on public.bookings(realtor_id, appointment_time);
 create table public.scheduled_messages (
     id             bigserial primary key,
     phone          varchar(50) not null references public.leads(phone) on delete cascade,
-    realtor_id     bigint not null references public.realtor(realtor_id) on delete cascade,
+    realtor_id     uuid not null references public.realtor(realtor_id) on delete cascade,
     scheduled_time timestamptz not null,
     message_type   varchar(20) default 'text',
     message_status varchar(20) default 'pending',
@@ -149,7 +147,7 @@ create table public.scheduled_messages (
 
 /* 2-e Google OAuth credentials */
 create table public.google_credentials (
-    realtor_id    bigint primary key references public.realtor(realtor_id) on delete cascade,
+    realtor_id    uuid primary key references public.realtor(realtor_id) on delete cascade,
     access_token  varchar(255) not null,
     refresh_token varchar(255) not null,
     token_expires timestamptz not null,
@@ -159,7 +157,7 @@ create table public.google_credentials (
 /* 2-f Synced Google Calendar events */
 create table public.google_calendar_events (
     id              bigserial primary key,
-    realtor_id      bigint not null references public.realtor(realtor_id) on delete cascade,
+    realtor_id      uuid not null references public.realtor(realtor_id) on delete cascade,
     google_event_id varchar(255) not null,
     summary         varchar(255),
     description     text,
@@ -174,26 +172,26 @@ create index on public.google_calendar_events(google_event_id);
 --    (HTML in video_url is quoted with $$ to avoid escaping hell)
 -- ─────────────────────────────────────────────────────────────
 insert into public.realtor
-    (uuid, phone, f_name, e_name, video_url, email, website_url)
+    (uuid, f_name, e_name, video_url, website_url)
 values
     ('a1b2c3d4-e5f6-4321-8765-1a2b3c4d5e6f',
-     '123-456-7890','Alice','Johnson',null,null,null),
+     'Alice','Johnson',null,null),
 
     ('b2c3d4e5-f6a7-5432-8765-2b3c4d5e6f7a',
-     '123-456-7891','Bob','Smith',null,null,null),
+     'Bob','Smith',null,null),
 
     ('c3d4e5f6-a7b8-6543-8765-3c4d5e6f7a8b',
-     '123-456-7892','Carol','Davis',$$
+     'Carol','Davis',$$
 <iframe src="https://player.vimeo.com/video/1068770376?h=fb9b1d993b&amp;title=0&amp;byline=0&amp;portrait=0&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479"
         frameborder="0" allow="autoplay; fullscreen; picture-in-picture; clipboard-write; encrypted-media"
         style="position:absolute;top:0;left:0;width:100%;height:100%;"
         title="IMG_5159"></iframe>$$,
-     'sifontana1965@gmail.com','https://www.audi.com/en/'),
+     'https://www.audi.com/en/'),
 
     ('f957761b-104e-416e-a550-25e010ca9302',
-     '123-456-7893','Alfonso','Mac',$$
+     'Alfonso','Mac',$$
 <iframe src="https://player.vimeo.com/video/1068770376?h=fb9b1d993b&amp;title=0&amp;byline=0&amp;portrait=0&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479"
         frameborder="0" allow="autoplay; fullscreen; picture-in-picture; clipboard-write; encrypted-media"
         style="position:absolute;top:0;left:0;width:100%;height:100%;"
         title="IMG_5159"></iframe>$$,
-     'skovdepeter@gmail.com','https://www.ferrari.com/en-BR');
+     'https://www.ferrari.com/en-BR');

--- a/frontend/RealtorInterface/Onboarding/src/App.jsx
+++ b/frontend/RealtorInterface/Onboarding/src/App.jsx
@@ -1,5 +1,13 @@
 import React, { useState } from 'react';
-import { User, Mail, Phone, Calendar, Lock, ArrowRight, CheckCircle } from 'lucide-react';
+import {
+  User,
+  Mail,
+  Phone,
+  Calendar,
+  Lock,
+  ArrowRight,
+  CheckCircle,
+} from 'lucide-react';
 import { createClient } from '@supabase/supabase-js';
 
 const supabase = createClient(
@@ -9,33 +17,44 @@ const supabase = createClient(
 
 export default function App() {
   const [step, setStep] = useState(1);
-  const [info, setInfo] = useState({ firstName: '', lastName: '', email: '', phone: '' });
+  const [email, setEmail] = useState('');
+  const [info, setInfo] = useState({ firstName: '', lastName: '', phone: '' });
   const [realtor, setRealtor] = useState(null);
   const [password, setPassword] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [showSuccess, setShowSuccess] = useState(false);
   const [calendarConnected, setCalendarConnected] = useState(false);
 
-  const handleFirstSubmit = async (e) => {
+  const handleEmailSubmit = async (e) => {
     e.preventDefault();
     setIsLoading(true);
-    
+
+    await supabase.auth.signInWithOtp({ email });
+
+    setIsLoading(false);
+    setStep(2);
+  };
+
+  const handleInfoSubmit = async (e) => {
+    e.preventDefault();
+    setIsLoading(true);
+
     // Simulate API call
     setTimeout(() => {
       const mockData = {
         realtor_id: 'realtor_123',
-        name: `${info.firstName} ${info.lastName}`.trim()
+        name: `${info.firstName} ${info.lastName}`.trim(),
       };
       setRealtor(mockData);
       setIsLoading(false);
-      setStep(2);
+      setStep(3);
     }, 1500);
   };
 
   const handleCalendarLink = async () => {
     if (!realtor) return;
     setIsLoading(true);
-    
+
     // Simulate calendar connection
     setTimeout(() => {
       setIsLoading(false);
@@ -50,7 +69,7 @@ export default function App() {
     setIsLoading(true);
 
     await supabase.auth.signUp({
-      email: info.email,
+      email,
       password,
       options: { data: { realtorId: realtor?.realtor_id } },
     });
@@ -72,13 +91,21 @@ export default function App() {
         {/* Progress indicator */}
         <div className="mb-8">
           <div className="flex justify-between items-center mb-2">
-            <span className="text-white/80 text-sm font-medium">Step {step} of 2</span>
-            <span className="text-white/60 text-sm">{step === 1 ? 'Personal Info' : 'Setup Complete'}</span>
+            <span className="text-white/80 text-sm font-medium">
+              Step {step} of 3
+            </span>
+            <span className="text-white/60 text-sm">
+              {step === 1
+                ? 'Verify Email'
+                : step === 2
+                  ? 'Personal Info'
+                  : 'Setup Complete'}
+            </span>
           </div>
           <div className="w-full bg-white/20 rounded-full h-2">
             <div
               className="bg-gradient-to-r from-pink-400 to-purple-400 h-2 rounded-full transition-all duration-700 ease-out"
-              style={{ width: `${(step / 2) * 100}%` }}
+              style={{ width: `${(step / 3) * 100}%` }}
             ></div>
           </div>
         </div>
@@ -86,13 +113,58 @@ export default function App() {
         {/* Main card */}
         <div className="bg-white/10 backdrop-blur-lg rounded-3xl shadow-2xl border border-white/20 p-8 transform transition-all duration-500 hover:shadow-3xl">
           {step === 1 && (
-            <div className="space-y-6">
+            <form className="space-y-6" onSubmit={handleEmailSubmit}>
+              <div className="text-center mb-8">
+                <div className="inline-flex items-center justify-center w-16 h-16 bg-gradient-to-r from-pink-400 to-purple-400 rounded-full mb-4">
+                  <Mail className="w-8 h-8 text-white" />
+                </div>
+                <h2 className="text-3xl font-bold text-white mb-2">
+                  Verify your email
+                </h2>
+                <p className="text-white/70">
+                  We'll send you a link to confirm it
+                </p>
+              </div>
+
+              <div className="relative">
+                <Mail className="absolute left-3 top-3.5 w-5 h-5 text-white/50" />
+                <input
+                  type="email"
+                  placeholder="Email address"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  required
+                  className="w-full bg-white/10 backdrop-blur-sm border border-white/20 rounded-xl pl-12 pr-4 py-3 text-white placeholder-white/50 focus:outline-none focus:ring-2 focus:ring-pink-400/50 focus:border-transparent transition-all duration-300"
+                />
+              </div>
+
+              <button
+                type="submit"
+                disabled={isLoading}
+                className="w-full bg-gradient-to-r from-pink-500 to-purple-500 hover:from-pink-600 hover:to-purple-600 text-white font-semibold py-3 px-6 rounded-xl shadow-lg hover:shadow-xl transform hover:-translate-y-0.5 transition-all duration-300 flex items-center justify-center space-x-2 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {isLoading ? (
+                  <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-white"></div>
+                ) : (
+                  <>
+                    <span>Send Link</span>
+                    <ArrowRight className="w-5 h-5" />
+                  </>
+                )}
+              </button>
+            </form>
+          )}
+
+          {step === 2 && (
+            <form className="space-y-6" onSubmit={handleInfoSubmit}>
               <div className="text-center mb-8">
                 <div className="inline-flex items-center justify-center w-16 h-16 bg-gradient-to-r from-pink-400 to-purple-400 rounded-full mb-4">
                   <User className="w-8 h-8 text-white" />
                 </div>
-                <h2 className="text-3xl font-bold text-white mb-2">Welcome!</h2>
-                <p className="text-white/70">Let's get you started with your account</p>
+                <h2 className="text-3xl font-bold text-white mb-2">
+                  Tell us about yourself
+                </h2>
+                <p className="text-white/70">We just need a few details</p>
               </div>
 
               <div className="space-y-4">
@@ -102,7 +174,9 @@ export default function App() {
                       type="text"
                       placeholder="First name"
                       value={info.firstName}
-                      onChange={(e) => setInfo({ ...info, firstName: e.target.value })}
+                      onChange={(e) =>
+                        setInfo({ ...info, firstName: e.target.value })
+                      }
                       required
                       className="w-full bg-white/10 backdrop-blur-sm border border-white/20 rounded-xl px-4 py-3 text-white placeholder-white/50 focus:outline-none focus:ring-2 focus:ring-pink-400/50 focus:border-transparent transition-all duration-300"
                     />
@@ -112,23 +186,13 @@ export default function App() {
                       type="text"
                       placeholder="Last name"
                       value={info.lastName}
-                      onChange={(e) => setInfo({ ...info, lastName: e.target.value })}
+                      onChange={(e) =>
+                        setInfo({ ...info, lastName: e.target.value })
+                      }
                       required
                       className="w-full bg-white/10 backdrop-blur-sm border border-white/20 rounded-xl px-4 py-3 text-white placeholder-white/50 focus:outline-none focus:ring-2 focus:ring-pink-400/50 focus:border-transparent transition-all duration-300"
                     />
                   </div>
-                </div>
-
-                <div className="relative">
-                  <Mail className="absolute left-3 top-3.5 w-5 h-5 text-white/50" />
-                  <input
-                    type="email"
-                    placeholder="Email address"
-                    value={info.email}
-                    onChange={(e) => setInfo({ ...info, email: e.target.value })}
-                    required
-                    className="w-full bg-white/10 backdrop-blur-sm border border-white/20 rounded-xl pl-12 pr-4 py-3 text-white placeholder-white/50 focus:outline-none focus:ring-2 focus:ring-pink-400/50 focus:border-transparent transition-all duration-300"
-                  />
                 </div>
 
                 <div className="relative">
@@ -137,7 +201,9 @@ export default function App() {
                     type="text"
                     placeholder="Phone number"
                     value={info.phone}
-                    onChange={(e) => setInfo({ ...info, phone: e.target.value })}
+                    onChange={(e) =>
+                      setInfo({ ...info, phone: e.target.value })
+                    }
                     required
                     className="w-full bg-white/10 backdrop-blur-sm border border-white/20 rounded-xl pl-12 pr-4 py-3 text-white placeholder-white/50 focus:outline-none focus:ring-2 focus:ring-pink-400/50 focus:border-transparent transition-all duration-300"
                   />
@@ -145,7 +211,7 @@ export default function App() {
               </div>
 
               <button
-                onClick={handleFirstSubmit}
+                type="submit"
                 disabled={isLoading}
                 className="w-full bg-gradient-to-r from-pink-500 to-purple-500 hover:from-pink-600 hover:to-purple-600 text-white font-semibold py-3 px-6 rounded-xl shadow-lg hover:shadow-xl transform hover:-translate-y-0.5 transition-all duration-300 flex items-center justify-center space-x-2 disabled:opacity-50 disabled:cursor-not-allowed"
               >
@@ -158,25 +224,32 @@ export default function App() {
                   </>
                 )}
               </button>
-            </div>
+            </form>
           )}
 
-          {step === 2 && (
+          {step === 3 && (
             <div className="space-y-6">
               <div className="text-center mb-8">
                 <div className="inline-flex items-center justify-center w-16 h-16 bg-gradient-to-r from-green-400 to-blue-400 rounded-full mb-4">
                   <Calendar className="w-8 h-8 text-white" />
                 </div>
-                <h2 className="text-3xl font-bold text-white mb-2">Almost Done!</h2>
-                <p className="text-white/70">Connect your calendar to finish setup</p>
+                <h2 className="text-3xl font-bold text-white mb-2">
+                  Almost Done!
+                </h2>
+                <p className="text-white/70">
+                  Connect your calendar to finish setup
+                </p>
               </div>
 
               <div className="bg-white/5 rounded-2xl p-6 border border-white/10">
-                <h3 className="text-lg font-semibold text-white mb-3">Connect Google Calendar</h3>
+                <h3 className="text-lg font-semibold text-white mb-3">
+                  Connect Google Calendar
+                </h3>
                 <p className="text-white/60 text-sm mb-4">
-                  Make sure you're logged into the correct Google account. If you encounter issues, try using an incognito window.
+                  Make sure you're logged into the correct Google account. If
+                  you encounter issues, try using an incognito window.
                 </p>
-                
+
                 <button
                   type="button"
                   onClick={handleCalendarLink}


### PR DESCRIPTION
## Summary
- link `realtor` table to `auth.users` and remove duplicated fields
- adjust backend services for uuid realtor IDs
- update SQL seeds to match new schema
- extend onboarding with email verification step

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685550c041c4832ebf66224aad1822e4