### PR TITLE
Add onboarding email verification instructions

### DIFF
--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -2,6 +2,10 @@
 
 This short guide explains how to link a Google Calendar so that bookings created through the website and the AI are kept in sync.
 
+## Verify your email
+
+On the first page you will be asked for your email address. After clicking **Send Link** check your inbox and open the verification URL. Once the email is confirmed, return to the onboarding page to continue with step 2.
+
 The admin dashboard exposes a **Link Google Calendar** button during the onboarding process. Clicking it will open the Google consent screen using the `/api/calendar/oauth/<realtorId>` endpoint. After granting access the backend receives a refresh token so future calendar calls work without additional prompts.
 
 1. Ensure the backend is running and accessible. The `GOOGLE_REDIRECT_URI` environment variable must point to

--- a/frontend/RealtorInterface/Onboarding/src/App.jsx
+++ b/frontend/RealtorInterface/Onboarding/src/App.jsx
@@ -180,6 +180,9 @@ export default function App() {
                   Tell us about yourself
                 </h2>
                 <p className="text-white/70">We just need a few details</p>
+                <p className="text-white/60 text-sm mt-1">
+                  Open the verification link sent to your email, then return here to continue.
+                </p>
               </div>
 
               <div className="space-y-4">


### PR DESCRIPTION
## Summary
- instruct users to verify their email and return to the onboarding page
- update onboarding React page with reminder after sending the email link

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685567078360832e92b16f921ee9b815