### PR TITLE
Fix survey redirect URL

### DIFF
--- a/frontend/survey/src/App.jsx
+++ b/frontend/survey/src/App.jsx
@@ -278,9 +278,10 @@ export default function App() {
       console.log('[frontend/survey/src/App.jsx]DEFAULT MESSAGE')
       if (sendToSite) {
         const siteUrl = new URL(window.location.href);
-        siteUrl.port = '4177';
-        console.log(`Redirecting to site: ${siteUrl.origin}/${realtorId}/${encodeURIComponent(phone)}`);
-        window.location.href = `${siteUrl.origin}/${realtorId}/${encodeURIComponent(phone)}`;
+        siteUrl.port = '';
+        siteUrl.pathname = '/s';
+        console.log(`Redirecting to site: ${siteUrl.origin}${siteUrl.pathname}/${realtorId}/${encodeURIComponent(phone)}`);
+        window.location.href = `${siteUrl.origin}${siteUrl.pathname}/${realtorId}/${encodeURIComponent(phone)}`;
         document.getElementById('successMessage').textContent =
         'Thank you for filling out the survey! You will be redirected to our website.';
       }


### PR DESCRIPTION
## Summary
- redirect survey finish page to `/s` path instead of using port 4177

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685569ab3034832e9d91b14f948b0f05