### PR TITLE
Fix OTP verification redirect for onboarding

### DIFF
--- a/frontend/RealtorInterface/Onboarding/src/App.jsx
+++ b/frontend/RealtorInterface/Onboarding/src/App.jsx
@@ -35,7 +35,10 @@ export default function App() {
     e.preventDefault();
     setIsLoading(true);
 
-    await supabase.auth.signInWithOtp({ email });
+    await supabase.auth.signInWithOtp({
+      email,
+      options: { emailRedirectTo: `${window.location.origin}/onboarding/` },
+    });
 
     setIsLoading(false);
     setStep(2);


### PR DESCRIPTION
## Summary
- ensure Supabase OTP links redirect back to `/onboarding/`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685574fb8fac832e971b98428e9766ee