### PR TITLE
Fix API route proxying

### DIFF
--- a/deploy/host-nginx/myrealvaluation.conf
+++ b/deploy/host-nginx/myrealvaluation.conf
@@ -16,7 +16,9 @@ server {
 
     # ── Backend API ────────────────────────────────────────────
     location /api/ {
-        proxy_pass http://localhost:3000/;
+        # Preserve the /api prefix when forwarding requests so that
+        # NestJS routes prefixed with `api` are matched correctly.
+        proxy_pass http://localhost:3000/api/;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
     }


### PR DESCRIPTION
## Summary
- update the nginx host config to preserve the `/api` prefix

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6858425ea630832ea19a630b5834df03