### PR TITLE
Fix API proxy path in nginx config

### DIFF
--- a/deploy/host-nginx/myrealvaluation.conf
+++ b/deploy/host-nginx/myrealvaluation.conf
@@ -16,7 +16,9 @@ server {
 
     # ── Backend API ────────────────────────────────────────────
     location /api/ {
-        proxy_pass http://localhost:3000/;
+        # Keep the /api prefix when proxying requests to the backend
+        # so NestJS can correctly match routes with the global "api" prefix
+        proxy_pass http://localhost:3000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
     }


### PR DESCRIPTION
## Summary
- proxy `/api` prefix correctly to backend so NestJS routes resolve

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6858425ea630832ea19a630b5834df03