### PR TITLE
Add auth UI to console

### DIFF
--- a/frontend/RealtorInterface/Console/src/LeadsList.jsx
+++ b/frontend/RealtorInterface/Console/src/LeadsList.jsx
@@ -10,6 +10,10 @@ const supabase = createClient(
 
 export default function LeadsList() {
   const [leads, setLeads] = useState([]);
+  const [session, setSession] = useState(null);
+  const [email, setEmail] = useState('');
+  const [emailSent, setEmailSent] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
 
   useEffect(() => {
     async function load() {
@@ -19,11 +23,90 @@ export default function LeadsList() {
     load();
   }, []);
 
+  useEffect(() => {
+    async function initAuth() {
+      if (window.location.hash.includes('access_token')) {
+        const params = new URLSearchParams(window.location.hash.substring(1));
+        const access_token = params.get('access_token');
+        const refresh_token = params.get('refresh_token');
+        if (access_token && refresh_token) {
+          await supabase.auth.setSession({ access_token, refresh_token });
+          window.location.hash = '';
+        }
+      }
+
+      const { data } = await supabase.auth.getSession();
+      setSession(data.session);
+
+      const {
+        data: { subscription },
+      } = supabase.auth.onAuthStateChange((_event, session) => {
+        setSession(session);
+      });
+
+      return () => subscription.unsubscribe();
+    }
+
+    initAuth();
+  }, []);
+
+  const handleLogin = async (e) => {
+    e.preventDefault();
+    await supabase.auth.signInWithOtp({
+      email,
+      options: { emailRedirectTo: 'https://www.myrealvaluation.com/console/' },
+    });
+    setEmailSent(true);
+  };
+
+  const handleLogout = async () => {
+    await supabase.auth.signOut();
+    setMenuOpen(false);
+  };
+
+  if (!session) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-indigo-400 to-purple-600 flex items-center justify-center p-6">
+        <div className="bg-white/90 backdrop-blur rounded-2xl shadow-xl p-8 w-full max-w-sm">
+          {emailSent ? (
+            <p className="text-center">Check your email ({email}) for a login link.</p>
+          ) : (
+            <form onSubmit={handleLogin} className="space-y-4">
+              <h1 className="text-xl font-bold text-center">Login</h1>
+              <input
+                type="email"
+                required
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="Email"
+                className="w-full border rounded p-2"
+              />
+              <button type="submit" className="w-full bg-blue-600 text-white rounded p-2">
+                Send Magic Link
+              </button>
+            </form>
+          )}
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-indigo-400 to-purple-600 p-6">
       <div className="container mx-auto bg-white/90 backdrop-blur rounded-2xl shadow-xl overflow-hidden">
         <div className="header bg-gradient-to-r from-slate-700 to-blue-500 text-white p-6 relative">
-          <Settings className="settings-cog absolute left-4 top-4 w-6 h-6" />
+          <Settings
+            className="settings-cog absolute left-4 top-4 w-6 h-6 cursor-pointer"
+            onClick={() => setMenuOpen((v) => !v)}
+          />
+          {menuOpen && (
+            <div className="absolute left-2 top-10 bg-white text-sm rounded shadow p-3 w-40">
+              <div className="mb-2 text-gray-700 break-words">{session.user.email}</div>
+              <button onClick={handleLogout} className="text-red-600 hover:underline">
+                Log Out
+              </button>
+            </div>
+          )}
           <h1 className="title text-2xl font-bold text-center">Leads Console</h1>
         </div>
         <div className="content p-6 grid gap-4">


### PR DESCRIPTION
## Summary
- add Supabase auth handling for Realtor console
- allow login by email OTP if no session
- display email and log out option from cog menu

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68584b7e615c832e8d5cc99882b46892