### PR TITLE
Redirect to console after calendar OAuth

### DIFF
--- a/backend/src/calendar/calendar.controller.ts
+++ b/backend/src/calendar/calendar.controller.ts
@@ -26,7 +26,7 @@ export class CalendarController {
   ) {
     const realtorId = state;
     await this.calendar.handleOAuthCallback(code, realtorId);
-    return res.redirect('/onboarding?connected=1');
+    return res.redirect('/console');
   }
 
   @Get('oauth/:realtorId')

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -16,9 +16,9 @@ The admin dashboard exposes a **Link Google Calendar** button during the onboard
    ```
    The response contains a `url` field. Open it in your browser.
 3. Grant access to the requested Google account and confirm the consent screen.
-4. After approval you will be redirected back to `/onboarding?connected=1`. At
-   this point the server automatically saves your Google refresh token in the
-   database so future calendar calls work without any additional steps.
+4. After approval you will be redirected directly to `/console`. The backend
+   automatically saves your Google refresh token so future calendar calls work
+   without any additional steps.
 
 Once this flow is completed, the application can create, update and delete
 calendar events without asking for permission again. Tokens are refreshed

--- a/frontend/RealtorInterface/Onboarding/src/App.jsx
+++ b/frontend/RealtorInterface/Onboarding/src/App.jsx
@@ -185,9 +185,6 @@ export default function App() {
     }
   };
 
-  const handleFinish = () => {
-    window.location.href = '/console';
-  };
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-indigo-900 via-purple-900 to-pink-800 flex items-center justify-center p-4">
@@ -436,20 +433,6 @@ export default function App() {
                 </button>
               </div>
 
-              <button
-                onClick={handleFinish}
-                disabled={isLoading || !calendarConnected}
-                className="w-full bg-gradient-to-r from-green-500 to-blue-500 hover:from-green-600 hover:to-blue-600 text-white font-semibold py-3 px-6 rounded-xl shadow-lg hover:shadow-xl transform hover:-translate-y-0.5 transition-all duration-300 flex items-center justify-center space-x-2 disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                {isLoading ? (
-                  <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-white"></div>
-                ) : (
-                  <>
-                    <CheckCircle className="w-5 h-5" />
-                    <span>Finish Setup</span>
-                  </>
-                )}
-              </button>
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary
- remove "Finish Setup" button from onboarding step 3
- redirect Google OAuth callback to `/console`
- document new redirect behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68585d73f66c832ea24b7e2eeee5ee02