### PR TITLE
Mark lead as hot on first message

### DIFF
--- a/backend/src/twilio/twilio.controller.ts
+++ b/backend/src/twilio/twilio.controller.ts
@@ -1,11 +1,15 @@
 import { Body, Controller, Logger, Post } from '@nestjs/common';
 import { AgentService } from '../agentLogic/agent.service';
+import { LeadsService } from '../leads/leads.service';
 
 @Controller('webhook')
 export class TwilioController {
   private readonly log = new Logger('TwilioWebhook');
 
-  constructor(private readonly agent: AgentService) {}
+  constructor(
+    private readonly agent: AgentService,
+    private readonly leads: LeadsService,
+  ) {}
 
   @Post('twilio')
   async handleWebhook(@Body() body: Record<string, unknown>) {
@@ -14,6 +18,7 @@ export class TwilioController {
     const message = typeof body.Body === 'string' ? body.Body : undefined;
     if (typeof from === 'string' && typeof message === 'string') {
       const phone = from.replace(/^whatsapp:/, '');
+      await this.leads.markHotIfCold(phone);
       await this.agent.send(phone, message);
     } else {
       this.log.warn('Invalid webhook payload');

--- a/frontend/RealtorInterface/Console/src/LeadsList.jsx
+++ b/frontend/RealtorInterface/Console/src/LeadsList.jsx
@@ -17,7 +17,9 @@ export default function LeadsList() {
 
   useEffect(() => {
     async function load() {
-      const { data } = await supabase.from('leads').select('phone,first_name,last_name,address');
+      const { data } = await supabase
+        .from('leads')
+        .select('phone,first_name,last_name,address,lead_state');
       setLeads(data || []);
     }
     load();
@@ -116,14 +118,19 @@ export default function LeadsList() {
               to={`reports/${encodeURIComponent(lead.phone)}`}
               className="lead-card block bg-white rounded-xl p-4 shadow hover:shadow-lg transition"
             >
-              <div className="flex justify-between">
+              <div className="flex justify-between items-center">
                 <div>
                   <div className="font-semibold text-gray-800">
                     {lead.first_name} {lead.last_name}
                   </div>
                   <div className="text-sm text-gray-600">{lead.address}</div>
                 </div>
-                <div className="font-mono text-blue-600">{lead.phone}</div>
+                <div className="text-right">
+                  <div className="font-mono text-blue-600">{lead.phone}</div>
+                  <div className="text-xs capitalize text-gray-500">
+                    {lead.lead_state}
+                  </div>
+                </div>
               </div>
             </Link>
           ))}


### PR DESCRIPTION
## Summary
- mark a lead as hot once they message in for the first time
- update Twilio webhook controller to flag hot leads
- surface lead state in the console UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68585fef4788832eb3198d20156f9673