### PR TITLE
Add STOP handling and message limit

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -29,3 +29,4 @@ This page summarises the variables defined in `.env.example` and what they are u
 
 ## Miscellaneous
 - `WEBHOOK_URL` – endpoint that receives lead data (used by the Facebook form utilities).
+- `MESSAGE_LIMIT` – maximum number of messages a user can receive before further texts are ignored.


### PR DESCRIPTION
## Summary
- cap outbound messages to 10 per phone number
- ignore webhook messages that contain only `STOP`
- document new `MESSAGE_LIMIT` environment variable

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685961a6a36c832eb6f718c6faaa84b9