### PR TITLE
Fix landing page asset path

### DIFF
--- a/frontend/site/vite.config.js
+++ b/frontend/site/vite.config.js
@@ -1,12 +1,12 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
-export default defineConfig({
-  base: './',
+export default defineConfig(({ mode }) => ({
+  base: mode === 'production' ? '/s/' : './',
   plugins: [react()],
   server: {
     proxy: {
       '/api': 'http://localhost:3000',
     },
   },
-});
+}));


### PR DESCRIPTION
## Summary
- set `/s/` base when building `frontend/site` so asset paths work under the landing-page URL

## Testing
- `npm test`
- `npm run build` for `frontend/site` (via vite)

------
https://chatgpt.com/codex/tasks/task_e_685966006c08832eb9e32fe071e102b2