### PR TITLE
Fix deploy timeout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,7 @@ jobs:
           host: ${{ secrets.SERVER_IP }}
           username: root
           password: ${{ secrets.SERVER_PASSWORD }}
+          command_timeout: 30m
           script: |
             cd /home/Lead
             git pull


### PR DESCRIPTION
## Summary
- extend SSH command timeout to let Docker builds finish

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859a0312cdc832e970d3d7c8e0d8148