### PR TITLE
Fix deploy workflow timeout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,7 @@ jobs:
           host: ${{ secrets.SERVER_IP }}
           username: root
           password: ${{ secrets.SERVER_PASSWORD }}
+          timeout: 30m
           command_timeout: 30m
           script: |
             cd /home/Lead


### PR DESCRIPTION
## Summary
- increase SSH timeout to 30 minutes to avoid premature disconnects during compose build

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859a31eb69c832ea2e5407f36197fc3