### PR TITLE
Fix realtor video regex

### DIFF
--- a/backend/src/realtor/dto/create-realtor.dto.ts
+++ b/backend/src/realtor/dto/create-realtor.dto.ts
@@ -25,6 +25,10 @@ export class CreateRealtorDto {
 
   @IsString()
   @IsOptional()
-  @Matches(/^https:\/\/player\.vimeo\.com/)
+  // Accept the full Vimeo iframe snippet copied from the embed dialog.
+  // Previous validation expected just the URL which caused a 400 error
+  // when the client submitted the entire <iframe> tag as instructed in
+  // the onboarding docs.
+  @Matches(/^<iframe.*player\.vimeo\.com/i)
   videoUrl?: string;
 }


### PR DESCRIPTION
## Summary
- permit full Vimeo iframe in realtor onboarding DTO

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685ab32fe328832e9bb4c640bf09fb1d