### PR TITLE
Fix phone format and disable past calendar days

### DIFF
--- a/frontend/site/src/App.css
+++ b/frontend/site/src/App.css
@@ -225,6 +225,12 @@ body {
   height: 40px;
 }
 
+.calendar-nav.disabled {
+  color: #555;
+  cursor: default;
+  pointer-events: none;
+}
+
 .calendar-nav:hover {
   background: #404040;
 }
@@ -278,6 +284,12 @@ body {
 
 .calendar-day.other-month {
   color: #555;
+}
+
+.calendar-day.past {
+  color: #555;
+  cursor: default;
+  pointer-events: none;
 }
 
 .calendar-day.today {

--- a/frontend/site/src/App.jsx
+++ b/frontend/site/src/App.jsx
@@ -15,7 +15,11 @@ export default function App() {
   const [bookingConfirmed, setBookingConfirmed] = useState(false);
 
   const formatPhone = (value) => {
-    const digits = value.replace(/\D/g, '').slice(0, 10);
+    let digits = value.replace(/\D/g, '');
+    if (digits.length > 10 && digits.startsWith('1')) {
+      digits = digits.slice(1);
+    }
+    digits = digits.slice(-10);
     let out = '';
     if (digits.length > 0) out += '(' + digits.slice(0, 3);
     if (digits.length >= 4) out += ') ' + digits.slice(3, 6);

--- a/frontend/site/src/components/BookingForm.jsx
+++ b/frontend/site/src/components/BookingForm.jsx
@@ -15,7 +15,11 @@ export default function BookingForm({ details, onBooked, user }) {
   }, [user]);
 
   const formatPhone = (value) => {
-    const digits = value.replace(/\D/g, '').slice(0, 10);
+    let digits = value.replace(/\D/g, '');
+    if (digits.length > 10 && digits.startsWith('1')) {
+      digits = digits.slice(1);
+    }
+    digits = digits.slice(-10);
     let out = '';
     if (digits.length > 0) out += '(' + digits.slice(0, 3);
     if (digits.length >= 4) out += ') ' + digits.slice(3, 6);

--- a/frontend/site/src/components/Callender.jsx
+++ b/frontend/site/src/components/Callender.jsx
@@ -14,6 +14,8 @@ function generateSlots() {
 
 export default function Callender({ realtorId, onSelect }) {
   const [currentDate, setCurrentDate] = useState(new Date());
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
   const [selectedDate, setSelectedDate] = useState(null);
   const [selectedTime, setSelectedTime] = useState(null);
   const [booked, setBooked] = useState([]);
@@ -70,7 +72,6 @@ export default function Callender({ realtorId, onSelect }) {
     const daysInPrevMonth = new Date(year, month, 0).getDate();
 
     const cells = [];
-    const today = new Date();
     const prevMonth = month === 0 ? 11 : month - 1;
     const prevYear = month === 0 ? year - 1 : year;
 
@@ -96,16 +97,17 @@ export default function Callender({ realtorId, onSelect }) {
 
     return cells.map((c, idx) => {
       const date = new Date(c.year, c.month, c.day);
-      const isToday =
-        date.toDateString() === today.toDateString();
+      const isToday = date.toDateString() === today.toDateString();
       const selected =
         selectedDate && date.toDateString() === selectedDate.toDateString();
+      const isPast = date < today;
       return (
         <div
           key={idx}
-          className={`calendar-day${c.other ? ' other-month' : ' '}$
-            {isToday ? ' today' : ''}${selected ? ' selected' : ''}`}
-          onClick={!c.other ? () => selectDate(c.year, c.month, c.day) : undefined}
+          className={`calendar-day${c.other ? ' other-month' : ''}$
+            {isToday ? ' today' : ''}${selected ? ' selected' : ''}$
+            {isPast && !isToday ? ' past' : ''}`}
+          onClick={!c.other && !isPast ? () => selectDate(c.year, c.month, c.day) : undefined}
         >
           {c.day}
         </div>
@@ -117,7 +119,12 @@ export default function Callender({ realtorId, onSelect }) {
   return (
     <div className="calendar">
       <div className="calendar-header">
-        <button className="calendar-nav" onClick={() => changeMonth(-1)}>
+        <button
+          className={`calendar-nav${
+            currentDate <= today ? ' disabled' : ''
+          }`}
+          onClick={currentDate > today ? () => changeMonth(-1) : undefined}
+        >
           ‹
         </button>
         <div className="calendar-month">

--- a/frontend/survey/src/App.jsx
+++ b/frontend/survey/src/App.jsx
@@ -27,7 +27,11 @@ export default function App() {
       return digits.slice(0, 5) + '-' + digits.slice(5);
     };
     const formatPhone = (value) => {
-      const digits = value.replace(/\D/g, '').slice(0, 10);
+      let digits = value.replace(/\D/g, '');
+      if (digits.length > 10 && digits.startsWith('1')) {
+        digits = digits.slice(1);
+      }
+      digits = digits.slice(-10);
       let out = '';
       if (digits.length > 0) out += '(' + digits.slice(0, 3);
       if (digits.length >= 4) out += ') ' + digits.slice(3, 6);


### PR DESCRIPTION
## Summary
- normalize phone number formatting across the site and survey
- disable selection of past days in booking calendar
- disable navigating to months before the current month

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ababe4afc832e8ef011f18a16020f