### PR TITLE
Remove automated booking reminder

### DIFF
--- a/frontend/site/src/App.jsx
+++ b/frontend/site/src/App.jsx
@@ -71,25 +71,7 @@ export default function App() {
       .finally(() => setLoading(false));
   }, []);
 
-  useEffect(() => {
-    const timer = setTimeout(
-      () => {
-        if (!bookingConfirmed && user?.phone) {
-          fetch('/api/schedule', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              phone: user.phone,
-              time: new Date().toISOString(),
-              content: 'Need help booking? Reply BOOK to schedule now.',
-            }),
-          });
-        }
-      },
-      5 * 60 * 1000,
-    );
-    return () => clearTimeout(timer);
-  }, [bookingConfirmed, user]);
+  // Removed the scheduled reminder text message
 
   if (loading) return <p>Loading...</p>;
   if (error) return <p>{error}</p>;


### PR DESCRIPTION
## Summary
- remove `useEffect` timer that scheduled booking reminder texts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685abcc474e0832ea436afe3f5ae57ca