### PR TITLE
Fix console build scripts

### DIFF
--- a/frontend/RealtorInterface/Console/package.json
+++ b/frontend/RealtorInterface/Console/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "node --env-file=../../../backend/.env ../../../node_modules/vite/bin/vite.js",
-    "build": "node --env-file=../../../backend/.env ../../../node_modules/vite/bin/vite.js build",
-    "preview": "node --env-file=../../../backend/.env ../../../node_modules/vite/bin/vite.js preview"
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.49.8",

--- a/frontend/RealtorInterface/Console/vite.config.js
+++ b/frontend/RealtorInterface/Console/vite.config.js
@@ -6,7 +6,7 @@ import { resolve } from 'path';
 // Load environment variables from the backend .env so local development
 // has access to the Supabase credentials without requiring a separate
 // .env file inside this package.
-config({ path: resolve(__dirname, '../../backend/.env') });
+config({ path: resolve(__dirname, '../../../backend/.env') });
 
 // Vite only exposes variables prefixed with `VITE_`. Mirror the backend
 // variables using that prefix so `import.meta.env` works as expected.


### PR DESCRIPTION
## Summary
- drop `--env-file` usage in console package.json scripts
- correct path to optional backend `.env` in Vite config

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685b06523248832e8ebce8812c0a5128