### PR TITLE
Remove obsolete compose version warning

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 
 services:
   # ── infrastructure ───────────────────────────────────────────


### PR DESCRIPTION
## Summary
- remove `version` field from `docker-compose.yml`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685b0adfe4d0832ea73c6e6b34d3ba34