### PR TITLE
Add startup log

### DIFF
--- a/frontend/RealtorInterface/Console/src/LeadReport.jsx
+++ b/frontend/RealtorInterface/Console/src/LeadReport.jsx
@@ -18,6 +18,10 @@ export default function LeadReport() {
   const [isEditing, setIsEditing] = useState(false);
 
   useEffect(() => {
+    console.log('the app has started');
+  }, []);
+
+  useEffect(() => {
     async function fetchReport() {
       const { data, error } = await supabase
         .from('leads')


### PR DESCRIPTION
## Summary
- add a simple start-up console log in `LeadReport.jsx`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b17f33708832eb480a09d3bd7960d