### PR TITLE
Fix supabase undefined error in LeadReport

### DIFF
--- a/frontend/RealtorInterface/Console/src/LeadReport.jsx
+++ b/frontend/RealtorInterface/Console/src/LeadReport.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { createClient } from '@supabase/supabase-js';
 import {
   User,
   Phone,
@@ -12,6 +13,11 @@ import {
   ArrowLeft,
 } from 'lucide-react';
 import { useParams, Link } from 'react-router-dom';
+
+const supabase = createClient(
+  import.meta.env.VITE_SUPABASE_URL,
+  import.meta.env.VITE_SUPABASE_ANON_KEY
+);
 export default function LeadReport() {
   const { phone } = useParams();
   const [leadData, setLeadData] = useState(null);


### PR DESCRIPTION
## Summary
- initialize Supabase client in `LeadReport.jsx` to fix `supabase is not defined` runtime error
- run existing Jest tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685b1a60fa04832ea95b9b350c07477b