### PR TITLE
Translate HTML titles to Portuguese

### DIFF
--- a/frontend/RealtorInterface/Console/index.html
+++ b/frontend/RealtorInterface/Console/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Lead Report</title>
+    <title>Relatório de Leads</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/RealtorInterface/Onboarding/index.html
+++ b/frontend/RealtorInterface/Onboarding/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Realtor Onboarding</title>
+    <title>Onboarding do Corretor</title>
     
   </head>
   <body>

--- a/frontend/StartPage/index.html
+++ b/frontend/StartPage/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>My Real Evaluation - Start Page</title>
+    <title>Minha Avaliação Real - Página Inicial</title>
     <style>
         * {
             margin: 0;

--- a/frontend/site/index.html
+++ b/frontend/site/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Site</title>
+    <title>Site Principal</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/survey/index.html
+++ b/frontend/survey/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Survey</title>
+    <title>Pesquisa</title>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- localize StartPage, Realtor Onboarding/Console, Survey and Site titles

## Testing
- `npm test`
- `python3 - <<'PY'
import bs4
files=[
 'frontend/StartPage/index.html',
 'frontend/RealtorInterface/Onboarding/index.html',
 'frontend/RealtorInterface/Console/index.html',
 'frontend/survey/index.html',
 'frontend/site/index.html'
]
for f in files:
    soup=bs4.BeautifulSoup(open(f).read(),'html.parser')
    print(f"{f}: {soup.title.string}")
PY`

------
https://chatgpt.com/codex/tasks/task_e_685b6a9c4388832e8f34320d57e524f3