### PR TITLE
Translate site to Portuguese

### DIFF
--- a/frontend/site/index.html
+++ b/frontend/site/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Site</title>
+<title>Site Imobiliário</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/site/src/App.jsx
+++ b/frontend/site/src/App.jsx
@@ -33,7 +33,7 @@ export default function App() {
     const idx = parts[0] === 's' ? 1 : 0;
     console.debug('Parsed path parts', parts, 'using idx', idx);
     if (parts.length - idx < 1) {
-      setError('Missing realtor id');
+      setError('ID do corretor ausente');
       setLoading(false);
       return;
     }
@@ -70,25 +70,25 @@ export default function App() {
       })
       .catch((err) => {
         console.error('Failed to load realtor', err);
-        setError('Failed to load realtor');
+        setError('Falha ao carregar corretor');
       })
       .finally(() => setLoading(false));
   }, []);
 
   // Removed the scheduled reminder text message
 
-  if (loading) return <p>Loading...</p>;
+  if (loading) return <p>Carregando...</p>;
   if (error) return <p>{error}</p>;
-  if (!realtor) return <p>No realtor found</p>;
+  if (!realtor) return <p>Nenhum corretor encontrado</p>;
 
   return (
     <>
       <header className="header">
-        <h1>Thank you for filling out the survey!</h1>
+        <h1>Obrigado por preencher a pesquisa!</h1>
         <p>
-          IMPORTANT!
+          IMPORTANTE!
           <br />
-          PLEASE WATCH THIS SHORT 1 MINUTE VIDEO
+          POR FAVOR ASSISTA A ESTE BREVE VÍDEO DE 1 MINUTO
         </p>
       </header>
 
@@ -97,9 +97,9 @@ export default function App() {
       </div>
 
       <div className="contact-section">
-        <div className="contact-text">MY TEAM WILL BE IN CONTACT SHORTLY</div>
+        <div className="contact-text">MINHA EQUIPE ENTRARÁ EM CONTATO EM BREVE</div>
         <div className="skip-text">
-          OR Skip the line and schedule a call with me NOW
+          OU pule a fila e agende uma ligação comigo AGORA
         </div>
         <div className="calendar-section">
           <Callender
@@ -116,7 +116,7 @@ export default function App() {
               setBookingConfirmed(true);
               if (selection) {
                 alert(
-                  `Thank you for booking a meeting with ${realtor.name} at ${selection.date} ${selection.time}. ${realtor.name} will soon enter contact with you.`,
+                  `Obrigado por agendar uma reunião com ${realtor.name} em ${selection.date} ${selection.time}. ${realtor.name} entrará em contato com você em breve.`,
                 );
               }
             }}
@@ -131,7 +131,7 @@ export default function App() {
               rel="noreferrer"
               className="btn btn-website"
             >
-              🌐 Visit My Website!
+              🌐 Visite meu site!
             </a>
           )}
         </div>

--- a/frontend/site/src/components/BookingForm.jsx
+++ b/frontend/site/src/components/BookingForm.jsx
@@ -43,7 +43,7 @@ export default function BookingForm({ details, onBooked, user }) {
 
     if (!form.name || !form.phone) {
       console.debug('Attempted booking with missing fields', form);
-      setStatus('Name and phone are required');
+      setStatus('Nome e telefone são obrigatórios');
       return;
     }
 
@@ -53,7 +53,7 @@ export default function BookingForm({ details, onBooked, user }) {
       time: details.time,
     });
 
-    setStatus('Submitting...');
+    setStatus('Enviando...');
     const res = await fetch('/api/bookings', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -69,10 +69,10 @@ export default function BookingForm({ details, onBooked, user }) {
     console.debug('Booking response status', res.status);
 
     if (res.ok) {
-      setStatus('Booked!');
+      setStatus('Agendado!');
       onBooked();
     } else {
-      setStatus('Failed');
+      setStatus('Falha');
     }
   };
 
@@ -86,7 +86,7 @@ export default function BookingForm({ details, onBooked, user }) {
           name="name"
           value={form.name}
           onChange={handle}
-          placeholder="Name"
+          placeholder="Nome"
           required
         />
       </div>
@@ -96,7 +96,7 @@ export default function BookingForm({ details, onBooked, user }) {
           name="phone"
           value={form.phone}
           onChange={handle}
-          placeholder="Phone"
+          placeholder="Telefone"
           inputMode="tel"
           pattern="\(\d{3}\) ?\d{3}-\d{4}"
           maxLength="14"
@@ -104,7 +104,7 @@ export default function BookingForm({ details, onBooked, user }) {
         />
       </div>
       <button type="submit" className="btn-book">
-        Confirm {details.date} {details.time}
+        Confirmar {details.date} {details.time}
       </button>
       {status && <p>{status}</p>}
     </form>


### PR DESCRIPTION
## Summary
- translate all visible strings in the site front-end to Portuguese
- translate placeholders and status messages in the booking form
- update HTML title

## Testing
- `npm test`
- `npm run build --workspace frontend/site`

------
https://chatgpt.com/codex/tasks/task_e_685b6a9b1b64832e84688ec2473e0866