### PR TITLE
Translate StartPage text to Portuguese

### DIFF
--- a/frontend/StartPage/src/App.jsx
+++ b/frontend/StartPage/src/App.jsx
@@ -24,7 +24,7 @@ export default function App() {
       <header>
         <div className="container">
           <div className="header-content">
-            <img src={logo} alt="My Real Evaluation Logo" className="logo-img" />
+            <img src={logo} alt="Logotipo da My Real Evaluation" className="logo-img" />
           </div>
         </div>
       </header>
@@ -32,50 +32,50 @@ export default function App() {
         <section className="hero">
             <div className="container">
                 <div className="hero-content">
-                    <h1>Smarter Real Estate Leads, Powered by AI</h1>
-                    <p>Connect with motivated sellers through the most intelligent and efficient lead generation platform built for realtors.</p>
-                    <a href="/onboarding" className="cta-button">Get Started – Realtor Sign-Up</a>
+                    <h1>Leads imobiliários mais inteligentes, impulsionados por IA</h1>
+                    <p>Conecte-se com vendedores motivados através da plataforma de geração de leads mais inteligente e eficiente, feita para corretores.</p>
+                    <a href="/onboarding" className="cta-button">Comece agora – Cadastro do Corretor</a>
                 </div>
             </div>
         </section>
     
         <section className="section what-we-do">
             <div className="container">
-                <h2 className="section-title">Helping You Connect With Homeowners Ready to Sell</h2>
+                <h2 className="section-title">Ajudando você a se conectar com proprietários prontos para vender</h2>
                 <div className="section-content">
-                    <p>At My Real Evaluation, we run high-converting online ads that offer free home evaluations to homeowners. Once they respond, our AI system engages with them directly, asks smart questions, and filters out the real prospects. We then hand off verified, high-intent leads to real estate agents like you.</p>
+                    <p>Na My Real Evaluation, executamos anúncios online de alta conversão que oferecem avaliações gratuitas de imóveis aos proprietários. Assim que respondem, nosso sistema de IA interage diretamente, faz perguntas inteligentes e filtra os verdadeiros interessados. Depois encaminhamos leads verificados e com alta intenção para corretores como você.</p>
                 </div>
             </div>
         </section>
     
         <section className="section why-different">
             <div className="container">
-                <h2 className="section-title">Not Just More Leads. Better Ones.</h2>
+                <h2 className="section-title">Não apenas mais leads. Leads melhores.</h2>
                 <div className="features-grid">
                     <div className="feature-card">
                         <span className="feature-icon">🤖</span>
-                        <h3 className="feature-title">AI-Powered Conversations</h3>
-                        <p className="feature-description">Every lead is pre-qualified by AI-driven chats that collect detailed data and gauge real interest.</p>
+                        <h3 className="feature-title">Conversas impulsionadas por IA</h3>
+                        <p className="feature-description">Cada lead é pré-qualificado por chats com IA que coletam dados detalhados e avaliam o interesse real.</p>
                     </div>
                     <div className="feature-card">
                         <span className="feature-icon">🔍</span>
-                        <h3 className="feature-title">Advanced Filtration System</h3>
-                        <p className="feature-description">Our custom filtration tools eliminate low-quality leads, so you waste no time chasing dead ends.</p>
+                        <h3 className="feature-title">Sistema avançado de filtragem</h3>
+                        <p className="feature-description">Nossas ferramentas personalizadas de filtragem eliminam leads de baixa qualidade para que você não perca tempo com casos sem futuro.</p>
                     </div>
                     <div className="feature-card">
                         <span className="feature-icon">📊</span>
-                        <h3 className="feature-title">Full Transparency</h3>
-                        <p className="feature-description">Access real-time conversations and lead information through our secure dashboard.</p>
+                        <h3 className="feature-title">Transparência total</h3>
+                        <p className="feature-description">Acesse conversas em tempo real e informações de leads através do nosso painel seguro.</p>
                     </div>
                     <div className="feature-card">
                         <span className="feature-icon">📈</span>
-                        <h3 className="feature-title">Weekly Performance Reports</h3>
-                        <p className="feature-description">Stay informed with automatic insights on ad performance and your top prospects.</p>
+                        <h3 className="feature-title">Relatórios semanais de desempenho</h3>
+                        <p className="feature-description">Mantenha-se informado com insights automáticos sobre o desempenho dos anúncios e seus principais prospects.</p>
                     </div>
                     <div className="feature-card">
                         <span className="feature-icon">🔒</span>
-                        <h3 className="feature-title">Secure Database Access</h3>
-                        <p className="feature-description">Leads are stored safely, and you can review every detail at your convenience.</p>
+                        <h3 className="feature-title">Acesso seguro ao banco de dados</h3>
+                        <p className="feature-description">Leads são armazenados com segurança e você pode revisar cada detalhe quando quiser.</p>
                     </div>
                 </div>
             </div>
@@ -83,27 +83,27 @@ export default function App() {
     
         <section className="section how-it-works">
             <div className="container">
-                <h2 className="section-title">A Seamless Process That Works For You</h2>
+                <h2 className="section-title">Um processo sem complicações que funciona para você</h2>
                 <div className="steps-container">
                     <div className="step">
                         <div className="step-number">1</div>
-                        <h3 className="step-title">We Run & Optimize Ads</h3>
-                        <p className="step-description">We run and optimize high-converting ads that attract motivated homeowners.</p>
+                        <h3 className="step-title">Executamos e otimizamos anúncios</h3>
+                        <p className="step-description">Executamos e otimizamos anúncios de alta conversão que atraem proprietários motivados.</p>
                     </div>
                     <div className="step">
                         <div className="step-number">2</div>
-                        <h3 className="step-title">AI Qualifies Leads</h3>
-                        <p className="step-description">AI chats with interested homeowners to evaluate intent and gather key information.</p>
+                        <h3 className="step-title">IA qualifica os leads</h3>
+                        <p className="step-description">A IA conversa com os proprietários interessados para avaliar intenção e coletar informações essenciais.</p>
                     </div>
                     <div className="step">
                         <div className="step-number">3</div>
-                        <h3 className="step-title">Leads Delivered</h3>
-                        <p className="step-description">Qualified leads are passed directly to your secure dashboard for immediate action.</p>
+                        <h3 className="step-title">Leads entregues</h3>
+                        <p className="step-description">Leads qualificados são enviados diretamente para o seu painel seguro para ação imediata.</p>
                     </div>
                     <div className="step">
                         <div className="step-number">4</div>
-                        <h3 className="step-title">Track Everything</h3>
-                        <p className="step-description">You track everything—live conversations, lead history, and performance results.</p>
+                        <h3 className="step-title">Acompanhe tudo</h3>
+                        <p className="step-description">Você acompanha tudo — conversas ao vivo, histórico de leads e resultados de desempenho.</p>
                     </div>
                 </div>
             </div>
@@ -111,8 +111,8 @@ export default function App() {
     
         <section className="final-cta">
             <div className="container">
-                <h2>Ready to grow your business with smarter leads?</h2>
-                <a href="/onboarding" className="cta-button">Get Started – Realtor Sign-Up</a>
+                <h2>Pronto para fazer seu negócio crescer com leads mais inteligentes?</h2>
+                <a href="/onboarding" className="cta-button">Comece agora – Cadastro do Corretor</a>
             </div>
         </section>
     


### PR DESCRIPTION
## Summary
- translate all visible text in `StartPage` to Portuguese
- confirm dev server renders Portuguese copy

## Testing
- `npm test`
- `npm run lint`
- `npm run dev` *(then curl check)*

------
https://chatgpt.com/codex/tasks/task_e_685b6a980c08832e93c96da67425f5c3