### PR TITLE
Fix onboarding supabase config

### DIFF
--- a/frontend/RealtorInterface/Onboarding/vite.config.js
+++ b/frontend/RealtorInterface/Onboarding/vite.config.js
@@ -1,5 +1,21 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { config } from 'dotenv';
+import { resolve } from 'path';
+
+// Load environment variables from the backend .env so local development
+// builds the app with the correct Supabase credentials without needing a
+// dedicated .env file inside this package.
+config({ path: resolve(__dirname, '../../../backend/.env') });
+
+// Vite only exposes variables prefixed with `VITE_`. Mirror the backend
+// variables using that prefix so `import.meta.env` works as expected.
+if (!process.env.VITE_SUPABASE_URL && process.env.SUPABASE_URL) {
+  process.env.VITE_SUPABASE_URL = process.env.SUPABASE_URL;
+}
+if (!process.env.VITE_SUPABASE_ANON_KEY && process.env.SUPABASE_ANON_KEY) {
+  process.env.VITE_SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY;
+}
 
 export default defineConfig(({ mode }) => ({
   base: mode === 'production' ? '/onboarding/' : './',


### PR DESCRIPTION
## Summary
- ensure the onboarding SPA loads Supabase credentials from backend/.env during local builds

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685bfe37b8d0832e96953d010396b9c0