### PR TITLE
Fix missing dotenv for onboarding build

### DIFF
--- a/frontend/RealtorInterface/Onboarding/package.json
+++ b/frontend/RealtorInterface/Onboarding/package.json
@@ -13,7 +13,8 @@
     "@types/react-dom": "^19.1.5",
     "lucide-react": "^0.514.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "dotenv": "^16.5.0"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.0",


### PR DESCRIPTION
## Summary
- include `dotenv` in the onboarding package so build works when vite config loads env vars

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c047ec0a0832ebf345d4e3db199d5