### PR TITLE
Fix server start with Node.js ESM

### DIFF
--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "module": "es2022",
+    "module": "commonjs",
     "moduleResolution": "node",
     "declaration": true,
     "removeComments": true,

--- a/package.json
+++ b/package.json
@@ -91,6 +91,6 @@
     "coverageDirectory": "../coverage",
     "testEnvironment": "node"
   },
-  "type": "module",
+  "type": "commonjs",
   "packageManager": "pnpm@8.6.10"
 }


### PR DESCRIPTION
## Summary
- compile backend as commonjs so `node` can resolve modules
- mark repo as commonjs for Node runtime

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e958f5104832e83a4e2c34d3fc019