### PR TITLE
Translate survey to Portuguese

### DIFF
--- a/frontend/survey/src/App.jsx
+++ b/frontend/survey/src/App.jsx
@@ -22,7 +22,7 @@ export default function App() {
     let sendToSite = true;
 
     const formatZip = (value) => {
-      const digits = value.replace(/\D/g, '').slice(0, 9);
+      const digits = value.replace(/\D/g, '').slice(0, 8);
       if (digits.length <= 5) return digits;
       return digits.slice(0, 5) + '-' + digits.slice(5);
     };
@@ -104,9 +104,9 @@ export default function App() {
       progressFill.style.width = progress + '%';
 
       if (currentStep === 'contact') {
-        progressText.textContent = 'Almost Done!';
+        progressText.textContent = 'Quase pronto!';
       } else {
-        progressText.textContent = `Step ${currentPosition}`;
+        progressText.textContent = `Etapa ${currentPosition}`;
       }
     }
 
@@ -131,7 +131,7 @@ export default function App() {
         nextBtn.style.display = 'none';
         submitBtn.style.display = 'inline-block';
         progressFill.style.width = '100%';
-        progressText.textContent = 'Final Step';
+        progressText.textContent = 'Etapa Final';
       } else {
         nextBtn.style.display = 'inline-block';
         submitBtn.style.display = 'none';
@@ -205,7 +205,7 @@ export default function App() {
 
     nextBtn.addEventListener('click', () => {
       if (!canProceed()) {
-        alert('Please answer the question before proceeding.');
+        alert('Responda à pergunta antes de continuar.');
         return;
       }
 
@@ -236,11 +236,11 @@ export default function App() {
     form.addEventListener('submit', async (e) => {
       e.preventDefault();
       if (!canProceed()) {
-        alert('Please fill in all required fields.');
+        alert('Preencha todos os campos obrigatórios.');
         return;
       }
 
-      submitBtn.innerHTML = 'Processing...';
+      submitBtn.innerHTML = 'Processando...';
       submitBtn.disabled = true;
 
       const formData = new FormData(form);
@@ -292,11 +292,11 @@ export default function App() {
         console.log(`Redirecting to site: ${siteUrl.origin}${siteUrl.pathname}/${realtorId}/${encodeURIComponent(phone)}`);
         window.location.href = `${siteUrl.origin}${siteUrl.pathname}/${realtorId}/${encodeURIComponent(phone)}`;
         document.getElementById('successMessage').textContent =
-        'Thank you for filling out the survey! You will be redirected to our website.';
+        'Obrigado por responder à pesquisa! Você será redirecionado para nosso site.';
       }
       else {
         document.getElementById('successMessage').textContent =
-        'Thank you! An agent will contact you soon.';
+        'Obrigado! Um agente entrará em contato em breve.';
       }
       document.getElementById('successMessage').style.display = 'block';
 

--- a/frontend/survey/src/markup.js
+++ b/frontend/survey/src/markup.js
@@ -1,22 +1,22 @@
 export const surveyMarkup = `
     <div class="survey-container">
         <div class="survey-header">
-            <h1>My Real Evaluation – Free Home Estimate Survey</h1>
+            <h1>My Real Evaluation – Avaliação Gratuita do Imóvel</h1>
             <div class="progress-bar">
                 <div class="progress-fill" id="progressFill"></div>
             </div>
-            <div class="progress-text" id="progressText">Getting Started</div>
+            <div class="progress-text" id="progressText">Iniciando</div>
         </div>
 
         <form class="survey-form" id="surveyForm">
             <!-- Question 1 -->
             <div class="question-group" id="q1">
-                <label class="question-label">What is your ZIP code? <span class="required">*</span></label>
+                <label class="question-label">Qual é o seu CEP? <span class="required">*</span></label>
                 <input
                     type="text"
                     name="zipcode"
                     required
-                    placeholder="Enter ZIP code"
+                    placeholder="Digite o CEP"
                     inputmode="numeric"
                     maxlength="10"
                 >
@@ -24,34 +24,34 @@ export const surveyMarkup = `
 
             <!-- Question 2 -->
             <div class="question-group hidden" id="q2">
-                <label class="question-label">What type of home is it?</label>
+                <label class="question-label">Qual é o tipo de imóvel?</label>
                 <div class="radio-group">
                     <label class="radio-option">
                         <input type="radio" name="homeType" value="single-family">
-                        Single-family home
+                        Casa
                     </label>
                     <label class="radio-option">
                         <input type="radio" name="homeType" value="condo">
-                        Condo or apartment
+                        Condomínio ou apartamento
                     </label>
                     <label class="radio-option">
                         <input type="radio" name="homeType" value="townhouse">
-                        Townhouse
+                        Sobrado
                     </label>
                     <label class="radio-option">
                         <input type="radio" name="homeType" value="duplex">
-                        Duplex / Multi-unit
+                        Duplex / Multiunidades
                     </label>
                     <label class="radio-option">
                         <input type="radio" name="homeType" value="other">
-                        Other
+                        Outro
                     </label>
                 </div>
             </div>
 
             <!-- Question 3 -->
             <div class="question-group hidden" id="q3">
-                <label class="question-label">How many bedrooms?</label>
+                <label class="question-label">Quantos quartos?</label>
                 <div class="radio-group">
                     <label class="radio-option">
                         <input type="radio" name="bedrooms" value="1">
@@ -78,7 +78,7 @@ export const surveyMarkup = `
 
             <!-- Question 4 -->
             <div class="question-group hidden" id="q4">
-                <label class="question-label">How many bathrooms?</label>
+                <label class="question-label">Quantos banheiros?</label>
                 <div class="radio-group">
                     <label class="radio-option">
                         <input type="radio" name="bathrooms" value="1">
@@ -86,7 +86,7 @@ export const surveyMarkup = `
                     </label>
                     <label class="radio-option">
                         <input type="radio" name="bathrooms" value="1.5">
-                        1.5
+                        1,5
                     </label>
                     <label class="radio-option">
                         <input type="radio" name="bathrooms" value="2">
@@ -94,7 +94,7 @@ export const surveyMarkup = `
                     </label>
                     <label class="radio-option">
                         <input type="radio" name="bathrooms" value="2.5">
-                        2.5
+                        2,5
                     </label>
                     <label class="radio-option">
                         <input type="radio" name="bathrooms" value="3+">
@@ -105,42 +105,42 @@ export const surveyMarkup = `
 
             <!-- Question 5 -->
             <div class="question-group hidden" id="q5">
-                <label class="question-label">What is the approximate square footage?</label>
+                <label class="question-label">Qual a metragem aproximada?</label>
                 <div class="radio-group">
                     <label class="radio-option">
                         <input type="radio" name="sqft" value="under-1000">
-                        Under 1,000 sq ft
+                        Menos de 1.000 pés²
                     </label>
                     <label class="radio-option">
                         <input type="radio" name="sqft" value="1000-1499">
-                        1,000–1,499 sq ft
+                        1.000–1.499 pés²
                     </label>
                     <label class="radio-option">
                         <input type="radio" name="sqft" value="1500-1999">
-                        1,500–1,999 sq ft
+                        1.500–1.999 pés²
                     </label>
                     <label class="radio-option">
                         <input type="radio" name="sqft" value="2000-2499">
-                        2,000–2,499 sq ft
+                        2.000–2.499 pés²
                     </label>
                     <label class="radio-option">
                         <input type="radio" name="sqft" value="2500+">
-                        2,500+ sq ft
+                        Acima de 2.500 pés²
                     </label>
                     <label class="radio-option">
                         <input type="radio" name="sqft" value="not-sure">
-                        Not sure
+                        Não sei
                     </label>
                 </div>
             </div>
 
             <!-- Question 6 -->
             <div class="question-group hidden" id="q6">
-                <label class="question-label">When was the home built?</label>
+                <label class="question-label">Quando o imóvel foi construído?</label>
                 <div class="radio-group">
                     <label class="radio-option">
                         <input type="radio" name="yearBuilt" value="before-1970">
-                        Before 1970
+                        Antes de 1970
                     </label>
                     <label class="radio-option">
                         <input type="radio" name="yearBuilt" value="1970-1990">
@@ -152,152 +152,152 @@ export const surveyMarkup = `
                     </label>
                     <label class="radio-option">
                         <input type="radio" name="yearBuilt" value="after-2010">
-                        After 2010
+                        Após 2010
                     </label>
                     <label class="radio-option">
                         <input type="radio" name="yearBuilt" value="not-sure">
-                        Not sure
+                        Não sei
                     </label>
                 </div>
             </div>
 
             <!-- Question 7 -->
             <div class="question-group hidden" id="q7">
-                <label class="question-label">What is the current occupancy status?</label>
+                <label class="question-label">Qual é a ocupação atual?</label>
                 <div class="radio-group">
                     <label class="radio-option">
                         <input type="radio" name="occupancy" value="i-live">
-                        I live in the property
+                        Eu moro no imóvel
                     </label>
                     <label class="radio-option">
                         <input type="radio" name="occupancy" value="rented">
-                        It is rented out
+                        Está alugado
                     </label>
                     <label class="radio-option">
                         <input type="radio" name="occupancy" value="vacant">
-                        It is currently vacant
+                        Está desocupado
                     </label>
                     <label class="radio-option">
                         <input type="radio" name="occupancy" value="other">
-                        Other
+                        Outro
                     </label>
                 </div>
             </div>
 
             <!-- Question 8 -->
             <div class="question-group hidden" id="q8">
-                <div class="section-header">Property Intent & Next Steps</div>
-                <label class="question-label">Do you see yourself selling this house in the foreseeable future?</label>
+                <div class="section-header">Intenção em relação ao imóvel e próximos passos</div>
+                <label class="question-label">Você pretende vender este imóvel em um futuro próximo?</label>
                 <div class="radio-group">
                     <label class="radio-option">
                         <input type="radio" name="changes" value="yes">
-                        Yes
+                        Sim
                     </label>
                     <label class="radio-option">
                         <input type="radio" name="changes" value="maybe">
-                        Maybe
+                        Talvez
                     </label>
                     <label class="radio-option">
                         <input type="radio" name="changes" value="no">
-                        No
+                        Não
                     </label>
                 </div>
             </div>
 
             <!-- Question 9 -->
             <div class="question-group hidden" id="q9">
-                <label class="question-label">If so, what is your estimated timeframe for making a decision?</label>
+                <label class="question-label">Se sim, qual é o prazo estimado para a decisão?</label>
                 <div class="radio-group">
                     <label class="radio-option">
                         <input type="radio" name="timeframe" value="immediate">
-                        Immediately
+                        Imediatamente
                     </label>
                     <label class="radio-option">
                         <input type="radio" name="timeframe" value="within-3-months">
-                        Within 3 months
+                        Dentro de 3 meses
                     </label>
                     <label class="radio-option">
                         <input type="radio" name="timeframe" value="6-months">
-                        6 months
+                        6 meses
                     </label>
                     <label class="radio-option">
                         <input type="radio" name="timeframe" value="year-plus">
-                        One year or more
+                        Um ano ou mais
                     </label>
                     <label class="radio-option">
                         <input type="radio" name="timeframe" value="not-sure">
-                        Not sure yet
+                        Ainda não sei
                     </label>
                 </div>
             </div>
 
             <!-- Question 10 -->
             <div class="question-group hidden" id="q10">
-                <label class="question-label">Have you already spoken with a real estate professional about this property?</label>
+                <label class="question-label">Você já falou com um profissional imobiliário sobre este imóvel?</label>
                 <div class="radio-group">
                     <label class="radio-option">
                         <input type="radio" name="professional" value="yes">
-                        Yes
+                        Sim
                     </label>
                     <label class="radio-option">
                         <input type="radio" name="professional" value="no">
-                        No
+                        Não
                     </label>
                 </div>
             </div>
 
             <!-- Question 11 -->
             <div class="question-group hidden" id="q11">
-                <label class="question-label">Would you be open to speaking with a trusted local expert for a more detailed home evaluation?</label>
+                <label class="question-label">Você gostaria de falar com um especialista local para uma avaliação mais detalhada do imóvel?</label>
                 <div class="radio-group">
                     <label class="radio-option">
                         <input type="radio" name="expert" value="yes">
-                        Yes
+                        Sim
                     </label>
                     <label class="radio-option">
                         <input type="radio" name="expert" value="no">
-                        No
+                        Não
                     </label>
                 </div>
             </div>
 
             <!-- Contact Section -->
             <div class="question-group hidden" id="contactInfo">
-                <div class="section-header">Contact Information</div>
-                <p style="margin-bottom: 20px; color: #666; font-size: 1.1rem;">Please provide your details so we can send your free estimate:</p>
+                <div class="section-header">Informações de Contato</div>
+                <p style="margin-bottom: 20px; color: #666; font-size: 1.1rem;">Forneça seus dados para que possamos enviar sua avaliação gratuita:</p>
                 <div class="contact-fields">
                     <div class="contact-field">
-                        <label>Full Name <span class="required">*</span></label>
-                        <input type="text" name="fullName" required placeholder="Enter your full name">
+                        <label>Nome Completo <span class="required">*</span></label>
+                        <input type="text" name="fullName" required placeholder="Digite seu nome completo">
                     </div>
                     <div class="contact-field">
-                        <label>Phone Number <span class="required">*</span></label>
+                        <label>Telefone <span class="required">*</span></label>
                         <input
                             type="text"
                             name="phone"
                             required
-                            placeholder="(555) 123-4567"
+                            placeholder="(11) 99999-9999"
                             inputmode="tel"
                             maxlength="14"
                         >
                     </div>
                     <div class="contact-field">
-                        <label>Email Address (optional)</label>
-                        <input type="text" name="email" placeholder="your.email@example.com">
+                        <label>Email (opcional)</label>
+                        <input type="text" name="email" placeholder="seu.email@exemplo.com">
                     </div>
                 </div>
                     <div class="consent-field">
                     <label style="display:flex;align-items:flex-start;gap:8px;">
                         <input type="checkbox" name="consent" required style="margin-top:4px;">
-                        <span><span class="required">*</span>&nbsp;I agree to receive marketing text messages from My Real Evaluation at the number I provided. These may be sent using automated technology, and my consent is not required to make a purchase. Message &amp; data rates may apply. I can opt out at any time by replying STOP.</span>
+                        <span><span class="required">*</span>&nbsp;Concordo em receber mensagens de texto de marketing da My Real Evaluation no número fornecido. Elas podem ser enviadas por tecnologia automatizada e meu consentimento não é obrigatório para realizar uma compra. Tarifas de mensagem e dados podem ser aplicadas. Posso cancelar a qualquer momento respondendo PARAR.</span>
                     </label>
                 </div>
             </div>
 
             <div class="navigation-buttons">
-                <button type="button" class="nav-btn next-btn" id="nextBtn">Next</button>
-                <button type="submit" class="nav-btn submit-btn" id="submitBtn" style="display: none;">Get My Free Estimate</button>
-                <button type="button" class="nav-btn prev-btn" id="prevBtn" disabled>Previous</button>
+                <button type="button" class="nav-btn next-btn" id="nextBtn">Próximo</button>
+                <button type="submit" class="nav-btn submit-btn" id="submitBtn" style="display: none;">Receber Avaliação Gratuita</button>
+                <button type="button" class="nav-btn prev-btn" id="prevBtn" disabled>Anterior</button>
             </div>
 
             <div id="successMessage" class="success-message" style="display: none;"></div>


### PR DESCRIPTION
## Summary
- localize survey markup in Portuguese
- update phone placeholder and consent wording
- show progress text in Portuguese
- sanitize CEP format
- convert UI messages to Portuguese

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e9d123628832e9f6295de924371c4