### PR TITLE
Adjust survey area ranges

### DIFF
--- a/database/postgres.sql
+++ b/database/postgres.sql
@@ -44,11 +44,11 @@ create type public.home_type_enum as enum (
 create type public.bedrooms_enum as enum ('1','2','3','4','5+');
 create type public.bathrooms_enum as enum ('1','1.5','2','2.5','3+');
 create type public.sqft_enum as enum (
-    'under-1000',
-    '1000-1499',
-    '1500-1999',
-    '2000-2499',
-    '2500+',
+    'under-50',
+    '50-99',
+    '100-149',
+    '150-199',
+    '200+',
     'not-sure'
 );
 create type public.year_built_enum as enum (

--- a/docs/UserTesting/survey-testing.md
+++ b/docs/UserTesting/survey-testing.md
@@ -19,7 +19,7 @@ curl -X POST http://134.199.198.237:3000/api/leads \
     "homeType": "single-family",
     "bedrooms": "3",
     "bathrooms": "2",
-    "sqft": "1500-1999",
+    "sqft": "100-149",
     "yearBuilt": "1990-2010",
     "occupancy": "i-live",
     "timeframe": "within-3-months",

--- a/frontend/survey/src/markup.js
+++ b/frontend/survey/src/markup.js
@@ -108,24 +108,24 @@ export const surveyMarkup = `
                 <label class="question-label">Qual a metragem aproximada?</label>
                 <div class="radio-group">
                     <label class="radio-option">
-                        <input type="radio" name="sqft" value="under-1000">
-                        Menos de 1.000 pés²
+                        <input type="radio" name="sqft" value="under-50">
+                        Menos de 50 m²
                     </label>
                     <label class="radio-option">
-                        <input type="radio" name="sqft" value="1000-1499">
-                        1.000–1.499 pés²
+                        <input type="radio" name="sqft" value="50-99">
+                        50–99 m²
                     </label>
                     <label class="radio-option">
-                        <input type="radio" name="sqft" value="1500-1999">
-                        1.500–1.999 pés²
+                        <input type="radio" name="sqft" value="100-149">
+                        100–149 m²
                     </label>
                     <label class="radio-option">
-                        <input type="radio" name="sqft" value="2000-2499">
-                        2.000–2.499 pés²
+                        <input type="radio" name="sqft" value="150-199">
+                        150–199 m²
                     </label>
                     <label class="radio-option">
-                        <input type="radio" name="sqft" value="2500+">
-                        Acima de 2.500 pés²
+                        <input type="radio" name="sqft" value="200+">
+                        Acima de 200 m²
                     </label>
                     <label class="radio-option">
                         <input type="radio" name="sqft" value="not-sure">


### PR DESCRIPTION
## Summary
- use smaller area options in square meters for Brazilian users
- update database enum and testing docs accordingly

## Testing
- `pnpm exec vitest run`


------
https://chatgpt.com/codex/tasks/task_e_685ea1941580832ebd63eba9d3d157df