### PR TITLE
Translate follow-up prompts to Portuguese

### DIFF
--- a/docs/UserTesting/survey-testing.md
+++ b/docs/UserTesting/survey-testing.md
@@ -35,7 +35,7 @@ To replicate the reminder WhatsApp message that the survey normally triggers, ca
 ```bash
 curl -X POST http://134.199.198.237:3000/api/schedule \
   -H 'Content-Type: application/json' \
-  --data-raw '{"phone":"+5511999999999","time":"2025-06-09T18:18:17Z","content":"Hi Jane Tester, thanks for taking the time to fill out the home valuation survey. To help refine your estimate, I would like to ask a couple of quick questions.\n\nCould you tell me about any recent updates or improvements you have made to the property? Things like kitchen remodels, new roofing, or updated flooring can really influence value."}'
+  --data-raw '{"phone":"+5511999999999","time":"2025-06-09T18:18:17Z","content":"Olá Jane Tester, obrigado por dedicar seu tempo para preencher a pesquisa de avaliação de imóvel. Para ajudar a refinar sua estimativa, gostaria de fazer algumas perguntas rápidas.\n\nVocê poderia me contar um pouco sobre quaisquer atualizações ou melhorias recentes que tenha feito na propriedade? Coisas como reforma da cozinha, telhado novo ou piso atualizado podem influenciar bastante o valor."}'
 ```
 
 This queues the message in Supabase and the Scheduler service will deliver it at the specified time.

--- a/frontend/survey/src/App.jsx
+++ b/frontend/survey/src/App.jsx
@@ -307,9 +307,9 @@ export default function App() {
           time: new Date(Date.now() + 1 * 60 * 1000).toISOString(),
           phone,
           content:
-            `Hi ${name}, thanks for taking the time to fill out the home valuation survey. To help refine your estimate, I’d like to ask a couple of quick questions.
+            `Olá ${name}, obrigado por dedicar seu tempo para preencher a pesquisa de avaliação de imóvel. Para ajudar a refinar sua estimativa, gostaria de fazer algumas perguntas rápidas.
 
-Could you tell me a bit about any recent updates or improvements you’ve made to the property? Things like kitchen remodels, new roofing, or updated flooring can really influence value.
+Você poderia me contar um pouco sobre quaisquer atualizações ou melhorias recentes que tenha feito na propriedade? Coisas como reforma da cozinha, telhado novo ou piso atualizado podem influenciar bastante o valor.
 `,
         }),
       });


### PR DESCRIPTION
## Summary
- translate reminder message in survey app
- update docs to match Portuguese wording

## Testing
- `pnpm test` *(fails: watch mode canceled)*

------
https://chatgpt.com/codex/tasks/task_e_685eb8287430832eaf89891032bb5965