### PR TITLE
Remove editing from lead report

### DIFF
--- a/frontend/RealtorInterface/Console/src/LeadReport.jsx
+++ b/frontend/RealtorInterface/Console/src/LeadReport.jsx
@@ -7,16 +7,12 @@ import {
   Hash,
   FileText,
   MessageSquare,
-  Edit3,
-  Save,
-  X,
   ArrowLeft,
 } from 'lucide-react';
 import { useParams, Link } from 'react-router-dom';
 export default function LeadReport() {
   const { phone } = useParams();
   const [leadData, setLeadData] = useState(null);
-  const [isEditing, setIsEditing] = useState(false);
 
   useEffect(() => {
     async function fetchReport() {
@@ -36,21 +32,7 @@ export default function LeadReport() {
     fetchReport();
   }, [phone]);
 
-  const handleInputChange = (field, value) => {
-    setLeadData((prev) => ({
-      ...prev,
-      [field]: value,
-    }));
-  };
 
-  const handleSave = () => {
-    setIsEditing(false);
-    // typically you would persist changes here
-  };
-
-  const handleCancel = () => {
-    setIsEditing(false);
-  };
 
   if (!leadData) return <div className="p-4">Loading...</div>;
 
@@ -70,34 +52,7 @@ export default function LeadReport() {
                   <p className="text-blue-100">Comprehensive lead information and analysis</p>
                 </div>
               </div>
-              <div className="flex gap-3">
-                {!isEditing ? (
-                  <button
-                    onClick={() => setIsEditing(true)}
-                    className="bg-white/20 hover:bg-white/30 text-white px-4 py-2 rounded-lg flex items-center gap-2 transition-all duration-200"
-                  >
-                    <Edit3 size={18} />
-                    Edit
-                  </button>
-                ) : (
-                  <div className="flex gap-2">
-                    <button
-                      onClick={handleSave}
-                      className="bg-green-500 hover:bg-green-600 text-white px-4 py-2 rounded-lg flex items-center gap-2 transition-all duration-200"
-                    >
-                      <Save size={18} />
-                      Save
-                    </button>
-                    <button
-                      onClick={handleCancel}
-                      className="bg-red-500 hover:bg-red-600 text-white px-4 py-2 rounded-lg flex items-center gap-2 transition-all duration-200"
-                    >
-                      <X size={18} />
-                      Cancel
-                    </button>
-                  </div>
-                )}
-              </div>
+              <div />
             </div>
           </div>
         </div>
@@ -113,52 +68,25 @@ export default function LeadReport() {
             <div className="space-y-4">
               <div className="group">
                 <label className="block text-sm font-medium text-gray-600 mb-2">Name</label>
-                {isEditing ? (
-                  <input
-                    type="text"
-                    value={leadData.name}
-                    onChange={(e) => handleInputChange('name', e.target.value)}
-                    className="w-full px-4 py-3 border border-gray-300 rounded-xl focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-200"
-                  />
-                ) : (
-                  <div className="bg-gray-50 px-4 py-3 rounded-xl font-medium text-gray-800">
-                    {leadData.name}
-                  </div>
-                )}
+                <div className="bg-gray-50 px-4 py-3 rounded-xl font-medium text-gray-800">
+                  {leadData.name}
+                </div>
               </div>
 
               <div className="group">
                 <label className="block text-sm font-medium text-gray-600 mb-2">Phone</label>
-                {isEditing ? (
-                  <input
-                    type="tel"
-                    value={leadData.phone}
-                    onChange={(e) => handleInputChange('phone', e.target.value)}
-                    className="w-full px-4 py-3 border border-gray-300 rounded-xl focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-200"
-                  />
-                ) : (
-                  <div className="bg-gray-50 px-4 py-3 rounded-xl font-medium text-gray-800 flex items-center gap-2">
-                    <Phone size={16} className="text-blue-600" />
-                    {leadData.phone}
-                  </div>
-                )}
+                <div className="bg-gray-50 px-4 py-3 rounded-xl font-medium text-gray-800 flex items-center gap-2">
+                  <Phone size={16} className="text-blue-600" />
+                  {leadData.phone}
+                </div>
               </div>
 
               <div className="group">
                 <label className="block text-sm font-medium text-gray-600 mb-2">Email</label>
-                {isEditing ? (
-                  <input
-                    type="email"
-                    value={leadData.email || ''}
-                    onChange={(e) => handleInputChange('email', e.target.value)}
-                    className="w-full px-4 py-3 border border-gray-300 rounded-xl focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-200"
-                  />
-                ) : (
-                  <div className="bg-gray-50 px-4 py-3 rounded-xl font-medium text-gray-800 flex items-center gap-2">
-                    <Mail size={16} className="text-blue-600" />
-                    {leadData.email || 'N/A'}
-                  </div>
-                )}
+                <div className="bg-gray-50 px-4 py-3 rounded-xl font-medium text-gray-800 flex items-center gap-2">
+                  <Mail size={16} className="text-blue-600" />
+                  {leadData.email || 'N/A'}
+                </div>
               </div>
             </div>
           </div>
@@ -172,19 +100,10 @@ export default function LeadReport() {
             <div className="space-y-4">
               <div className="group">
                 <label className="block text-sm font-medium text-gray-600 mb-2">ZIP code</label>
-                {isEditing ? (
-                  <input
-                    type="text"
-                    value={leadData.zipcode}
-                    onChange={(e) => handleInputChange('zipcode', e.target.value)}
-                    className="w-full px-4 py-3 border border-gray-300 rounded-xl focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-200"
-                  />
-                ) : (
-                  <div className="bg-gray-50 px-4 py-3 rounded-xl font-medium text-gray-800 flex items-center gap-2">
-                    <Hash size={16} className="text-blue-600" />
-                    {leadData.zipcode}
-                  </div>
-                )}
+                <div className="bg-gray-50 px-4 py-3 rounded-xl font-medium text-gray-800 flex items-center gap-2">
+                  <Hash size={16} className="text-blue-600" />
+                  {leadData.zipcode}
+                </div>
               </div>
             </div>
           </div>
@@ -198,18 +117,9 @@ export default function LeadReport() {
               Survey Summary
             </h2>
 
-            {isEditing ? (
-              <textarea
-                value={leadData.surveySummary}
-                onChange={(e) => handleInputChange('surveySummary', e.target.value)}
-                rows="6"
-                className="w-full px-4 py-3 border border-gray-300 rounded-xl focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-200 resize-none"
-              />
-            ) : (
-              <div className="bg-gradient-to-br from-blue-50 to-indigo-50 px-4 py-4 rounded-xl text-gray-700 leading-relaxed">
-                {leadData.surveySummary}
-              </div>
-            )}
+            <div className="bg-gradient-to-br from-blue-50 to-indigo-50 px-4 py-4 rounded-xl text-gray-700 leading-relaxed">
+              {leadData.surveySummary}
+            </div>
           </div>
 
           <div className="bg-white rounded-2xl shadow-lg p-6 hover:shadow-xl transition-shadow duration-300">
@@ -218,20 +128,9 @@ export default function LeadReport() {
               Message Summary
             </h2>
 
-            {isEditing ? (
-              <textarea
-                value={leadData.messageSummary?.content || ''}
-                onChange={(e) =>
-                  handleInputChange('messageSummary', { ...leadData.messageSummary, content: e.target.value })
-                }
-                rows="6"
-                className="w-full px-4 py-3 border border-gray-300 rounded-xl focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-200 resize-none"
-              />
-            ) : (
-              <div className="bg-gradient-to-br from-green-50 to-emerald-50 px-4 py-4 rounded-xl text-gray-700 leading-relaxed">
-                {leadData.messageSummary?.content}
-              </div>
-            )}
+            <div className="bg-gradient-to-br from-green-50 to-emerald-50 px-4 py-4 rounded-xl text-gray-700 leading-relaxed">
+              {leadData.messageSummary?.content}
+            </div>
           </div>
         </div>
 

--- a/frontend/RealtorInterface/Console/src/LeadsList.jsx
+++ b/frontend/RealtorInterface/Console/src/LeadsList.jsx
@@ -83,7 +83,7 @@ export default function LeadsList() {
 
   if (!session) {
     return (
-      <div className="min-h-screen bg-white flex items-center justify-center p-6">
+      <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-100 flex items-center justify-center p-6">
         <div className="bg-white/90 backdrop-blur rounded-2xl shadow-xl p-8 w-full max-w-sm">
           <button
             onClick={handleLogin}
@@ -97,7 +97,7 @@ export default function LeadsList() {
   }
 
   return (
-    <div className="min-h-screen bg-white p-6">
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-100 p-6">
       <div className="container mx-auto bg-white/90 backdrop-blur rounded-2xl shadow-xl overflow-hidden">
         <div className="header bg-gradient-to-r from-blue-600 to-indigo-700 text-white p-6 relative">
           <Settings


### PR DESCRIPTION
## Summary
- remove edit actions from `LeadReport`
- use the same gradient background on the leads list

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685ed784e340832ea1bb1fed10ee0b05