### PR TITLE
Add privacy policy page

### DIFF
--- a/deploy/host-nginx/myrealvaluation.conf
+++ b/deploy/host-nginx/myrealvaluation.conf
@@ -54,6 +54,10 @@ server {
         return 301 /sms-terms/;
     }
 
+    location = /privacy {
+        return 301 /privacy/;
+    }
+
     location /survey/ {
         proxy_pass http://localhost:4174;
         proxy_set_header Host $host;
@@ -79,6 +83,12 @@ server {
 
     location /sms-terms/ {
         proxy_pass http://localhost:4178;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
+    location /privacy/ {
+        proxy_pass http://localhost:4179;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,3 +94,14 @@ services:
       - api
     ports:
       - "4178:80"
+
+  privacy:
+    build:
+      context: .
+      dockerfile: frontend/privacy/Dockerfile
+    env_file:
+      - backend/.env
+    depends_on:
+      - api
+    ports:
+      - "4179:80"

--- a/docs/host-nginx.md
+++ b/docs/host-nginx.md
@@ -11,6 +11,7 @@ owns ports **80/443** and forwards requests to Docker-mapped ports:
 | `/onboarding` | `onboarding` | `4175` |
 | `/console` | `console` | `4176` |
 | `/sms-terms` | `smsterms` | `4178` |
+| `/privacy` | `privacy` | `4179` |
 | `/api/` | `api` | `3000` |
 
 ## Deployment steps

--- a/frontend/privacy/Dockerfile
+++ b/frontend/privacy/Dockerfile
@@ -1,0 +1,5 @@
+FROM nginx:alpine
+COPY frontend/privacy/nginx.conf /etc/nginx/conf.d/default.conf
+COPY frontend/privacy/index.html /usr/share/nginx/html/privacy/index.html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/privacy/index.html
+++ b/frontend/privacy/index.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Privacy Policy – My Real Evaluation</title>
+<style>
+  body{font-family:Arial,Helvetica,sans-serif;margin:40px;line-height:1.6}
+  h1{margin-bottom:20px}
+  h2{margin:24px 0 12px}
+  table{border-collapse:collapse;width:100%}
+  th,td{border:1px solid #ddd;padding:8px}
+  th{background:#f2f2f2}
+  a{color:#0645ad}
+</style>
+</head>
+<body>
+<h1 id="privacy">My Real Evaluation (MRE) – Privacy Policy</h1>
+<p><strong>Last updated:</strong> 28 June 2025</p>
+
+<h2>1. Who we are</h2>
+<p>
+  My Real Evaluation, Inc. (“MRE”, “we”, “our”, “us”)<br>
+  Address: [company address]<br>
+  Email: <a href="mailto:privacy@myrealvaluation.com">privacy@myrealvaluation.com</a>
+</p>
+
+<h2>2. What data we collect</h2>
+<table>
+<tr><th>Category</th><th>Examples</th><th>Source</th></tr>
+<tr><td>Contact data</td><td>Name, phone number, email, postal address</td><td>You or your Realtor</td></tr>
+<tr><td>Property data</td><td>Zip code, property attributes, listing details</td><td>Public records &amp; you</td></tr>
+<tr><td>Usage data</td><td>IP address, browser type, pages visited, cookies</td><td>Automatic</td></tr>
+<tr><td>SMS logs</td><td>Message content, delivery receipts</td><td>SMS gateway (Twilio/Meta)</td></tr>
+</table>
+
+<h2>3. How we use your data</h2>
+<ul>
+  <li>Deliver instant home-value estimates.</li>
+  <li>Send automated SMS updates (see “SMS Terms” below).</li>
+  <li>Connect you with licensed Realtors if you request it.</li>
+  <li>Improve our models, analytics, and fraud prevention.</li>
+</ul>
+
+<h2>4. Legal basis (GDPR / LGPD)</h2>
+<p>We process data on the basis of <em>legitimate interests</em>, <em>contract performance</em>, and your <em>consent</em> (for marketing texts).</p>
+
+<h2>5. Sharing your data</h2>
+<ul>
+  <li><strong>Realtor partners</strong> – only when you ask to be connected.</li>
+  <li><strong>Service providers</strong> – cloud hosting, SMS gateway, analytics; bound by contract.</li>
+  <li><strong>Regulators or law enforcement</strong> – where required by law.</li>
+</ul>
+<p>We <strong>never sell</strong> your personal data to third parties for their own marketing.</p>
+
+<h2>6. SMS Terms</h2>
+<p>
+Program: automated texts deliver your estimate and, if requested, connect you with a Realtor.<br>
+Frequency: up to 10 messages per valuation request; may vary.<br>
+Fees: Msg &amp; Data rates may apply.<br>
+Opt-out: reply <strong>STOP</strong> to cancel; <strong>HELP</strong> for help.<br>
+Privacy: mobile information is used solely to fulfill your request and is not shared for third-party marketing.
+</p>
+
+<h2>7. Cookies &amp; tracking</h2>
+<p>We use first-party cookies and Google Analytics to understand site usage. You can disable cookies in your browser settings.</p>
+
+<h2>8. Security</h2>
+<p>Data in transit is protected by TLS; at rest by AES-256. Access is role-based and logged.</p>
+
+<h2>9. Retention</h2>
+<p>
+Contact &amp; property data: 5 years after last interaction.<br>
+SMS logs: 1 year.<br>
+We delete or anonymize thereafter unless a longer period is required by law.
+</p>
+
+<h2>10. Your rights</h2>
+<p>
+You may access, correct, delete, or export your data and withdraw consent at any time by emailing
+<a href="mailto:privacy@myrealvaluation.com">privacy@myrealvaluation.com</a>.
+Residents of California, the EU, UK, and Brazil have additional statutory rights.
+</p>
+
+<h2>11. Children</h2>
+<p>Our service is not directed to children under 13; we do not knowingly collect data from them.</p>
+
+<h2>12. Changes to this policy</h2>
+<p>We will post changes here and update the “Last updated” date. Material changes will be announced via the app or SMS.</p>
+
+<h2>13. Contact</h2>
+<p>
+Questions? Email <a href="mailto:privacy@myrealvaluation.com">privacy@myrealvaluation.com</a> or write to the address above.
+</p>
+</body>
+</html>

--- a/frontend/privacy/nginx.conf
+++ b/frontend/privacy/nginx.conf
@@ -1,0 +1,7 @@
+server {
+    listen 80;
+    location /privacy/ {
+        alias /usr/share/nginx/html/privacy/;
+        try_files $uri $uri/ /privacy/index.html;
+    }
+}


### PR DESCRIPTION
## Summary
- add static privacy policy page under `frontend/privacy`
- serve `/privacy` via new nginx config and Docker container
- expose container on port 4179 in docker compose and host nginx
- document new path in hosting docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f681be7b4832e9bc14a30b823b01c