### PR TITLE
Add Terms of Service page

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This repository contains a small NestJS backend and two React front ends used to
   - Survey site: <https://www.myrealvaluation.com/survey>
   - Console: <https://www.myrealvaluation.com/console>
   - SMS Terms: <https://www.myrealvaluation.com/sms-terms>
+  - Terms of Service: <https://www.myrealvaluation.com/terms>
 
 ## Running with Docker Compose
 

--- a/deploy/host-nginx/myrealvaluation.conf
+++ b/deploy/host-nginx/myrealvaluation.conf
@@ -54,6 +54,10 @@ server {
         return 301 /sms-terms/;
     }
 
+    location = /terms {
+        return 301 /terms/;
+    }
+
     location /survey/ {
         proxy_pass http://localhost:4174;
         proxy_set_header Host $host;
@@ -79,6 +83,12 @@ server {
 
     location /sms-terms/ {
         proxy_pass http://localhost:4178;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
+    location /terms/ {
+        proxy_pass http://localhost:4179;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,3 +94,14 @@ services:
       - api
     ports:
       - "4178:80"
+
+  terms:
+    build:
+      context: .
+      dockerfile: frontend/terms/Dockerfile
+    env_file:
+      - backend/.env
+    depends_on:
+      - api
+    ports:
+      - "4179:80"

--- a/docs/host-nginx.md
+++ b/docs/host-nginx.md
@@ -11,6 +11,7 @@ owns ports **80/443** and forwards requests to Docker-mapped ports:
 | `/onboarding` | `onboarding` | `4175` |
 | `/console` | `console` | `4176` |
 | `/sms-terms` | `smsterms` | `4178` |
+| `/terms` | `terms` | `4179` |
 | `/api/` | `api` | `3000` |
 
 ## Deployment steps

--- a/frontend/terms/Dockerfile
+++ b/frontend/terms/Dockerfile
@@ -1,0 +1,5 @@
+FROM nginx:alpine
+COPY frontend/terms/nginx.conf /etc/nginx/conf.d/default.conf
+COPY frontend/terms/index.html /usr/share/nginx/html/terms/index.html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/terms/index.html
+++ b/frontend/terms/index.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Terms of Service – My Real Evaluation</title>
+<style>
+  body{font-family:Arial,Helvetica,sans-serif;margin:40px;line-height:1.6}
+  h1{margin-bottom:20px}
+  h2{margin:24px 0 12px}
+  a{color:#0645ad}
+</style>
+</head>
+<body>
+<h1>My Real Evaluation (MRE) – Terms of Service</h1>
+<p><strong>Last updated:</strong> 28 June 2025</p>
+
+<h2>1. Acceptance of Terms</h2>
+<p>
+By accessing or using the MRE website, mobile service, or SMS program (“Service”) you agree to these
+Terms of Service (“Terms”) and our
+<a href="/privacy">Privacy Policy</a>. If you do not agree, do not use the Service.
+</p>
+
+<h2>2. Eligibility</h2>
+<p>The Service is intended for individuals 18 years or older who can form legally binding contracts.</p>
+
+<h2>3. Description of Service</h2>
+<p>
+MRE provides automated home-value estimates and, at your request, introduces you to licensed real-estate professionals (“Realtors”). Estimates are informational only and do <strong>not</strong> constitute an appraisal or legal advice.
+</p>
+
+<h2>4. Accounts &amp; Authentication</h2>
+<ul>
+  <li>You are responsible for safeguarding your account credentials and any 2-step PINs.</li>
+  <li>You agree to notify us immediately of any unauthorized use.</li>
+</ul>
+
+<h2>5. License &amp; Acceptable Use</h2>
+<p>We grant you a limited, non-exclusive, revocable license to access the Service for personal, non-commercial use. You agree not to:</p>
+<ul>
+  <li>Scrape, reverse-engineer, or misuse data.</li>
+  <li>Use automated scripts to send requests or messages.</li>
+  <li>Upload malicious code or violate any law.</li>
+</ul>
+
+<h2>6. SMS Program Terms</h2>
+<p>
+By opting in, you consent to receive automated texts under the conditions outlined in Section 6 of our
+<a href="/privacy#sms-terms">Privacy Policy</a>.
+</p>
+
+<h2>7. Third-Party Services</h2>
+<p>
+We may link to or integrate third-party services (e.g., mapping, analytics). We are not responsible for their content or privacy practices.
+</p>
+
+<h2>8. Intellectual Property</h2>
+<p>
+All content, trademarks, logos, and software are the property of MRE or its licensors.
+You may not copy or distribute without prior written consent.
+</p>
+
+<h2>9. Disclaimers</h2>
+<ul>
+  <li>Home-value estimates are approximations; actual market value may differ.</li>
+  <li>The Service is provided “as is” without warranties of any kind.</li>
+</ul>
+
+<h2>10. Limitation of Liability</h2>
+<p>
+To the fullest extent permitted by law, MRE will not be liable for any indirect, incidental,
+special, or consequential damages arising out of or related to your use of the Service.
+</p>
+
+<h2>11. Indemnification</h2>
+<p>
+You agree to indemnify and hold harmless MRE from any claims or damages related to your use
+of the Service or violation of these Terms.
+</p>
+
+<h2>12. Governing Law &amp; Dispute Resolution</h2>
+<p>
+These Terms are governed by the laws of [jurisdiction]. Any dispute will be resolved
+through binding arbitration in [city, state], except either party may seek injunctive relief in court.
+</p>
+
+<h2>13. Changes to Terms</h2>
+<p>
+We may update these Terms at any time. Material changes will be posted here and, where appropriate,
+sent via SMS or email. Continued use after changes means you accept the revised Terms.
+</p>
+
+<h2>14. Contact</h2>
+<p>
+Questions about these Terms? Email
+<a href="mailto:admin@myrealvaluation.com">admin@myrealvaluation.com</a>.
+</p>
+</body>
+</html>
+

--- a/frontend/terms/nginx.conf
+++ b/frontend/terms/nginx.conf
@@ -1,0 +1,7 @@
+server {
+    listen 80;
+    location /terms/ {
+        alias /usr/share/nginx/html/terms/;
+        try_files $uri $uri/ /terms/index.html;
+    }
+}


### PR DESCRIPTION
## Summary
- create `frontend/terms` static site with ToS page
- update nginx host config and docker compose
- document new `/terms` path
- list the Terms page in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f68310658832e8ca59a22f2712a7a