### PR TITLE
Add WhatsApp test send API

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -30,6 +30,7 @@ import { RealtorService } from './realtor/realtor.service';
 import { ReportsController } from './reports/reports.controller';
 import { ReportsService } from './reports/reports.service';
 import { WhatsAppController } from './whatsapp/whatsapp.controller';
+import { WhatsAppTestController } from './whatsapp/test-send.controller';
 
 import { OpenAiService } from './agentHelp/openai.service';
 import { PromptService } from './agentHelp/prompt.service';
@@ -93,6 +94,7 @@ import { PromptService } from './agentHelp/prompt.service';
     SystemMessageController,
     ReportsController,
     WhatsAppController,
+    WhatsAppTestController,
   ],
   providers: [
     AppService,

--- a/backend/src/whatsapp/test-send.controller.ts
+++ b/backend/src/whatsapp/test-send.controller.ts
@@ -1,0 +1,17 @@
+import { Body, Controller, HttpCode, Post } from '@nestjs/common';
+import { WhatsAppService } from './whatsapp.service';
+
+@Controller('whatsapp')
+export class WhatsAppTestController {
+  constructor(private readonly whatsapp: WhatsAppService) {}
+
+  @Post('test')
+  @HttpCode(200)
+  async sendTest(
+    @Body('phone') phone: string,
+    @Body('message') message: string,
+  ) {
+    await this.whatsapp.sendMessage(phone, message);
+    return { status: 'attempted' };
+  }
+}

--- a/docs/UserTesting/message-testing.md
+++ b/docs/UserTesting/message-testing.md
@@ -23,3 +23,13 @@ The server replies with the assistant's message in JSON:
 ```
 
 A record is stored in the `message_logs` table and the conversation history is updated in Redis.
+
+To simply verify that WhatsApp messages can be sent without triggering the AI assistant, POST to `/whatsapp/test`:
+
+```bash
+curl -X POST http://134.199.198.237:3000/api/whatsapp/test \
+  -H "Content-Type: application/json" \
+  -d '{"phone": "5511999999999", "message": "hello world"}'
+```
+
+If the request succeeds, the server responds with `{"status":"attempted"}`.


### PR DESCRIPTION
## Summary
- add a controller to send WhatsApp test messages
- register the new controller in `AppModule`
- document how to use the new endpoint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68615fc73d74832e8684a355640dc794