### PR TITLE
Implement phone auto-registration

### DIFF
--- a/backend/src/whatsapp/whatsapp.service.ts
+++ b/backend/src/whatsapp/whatsapp.service.ts
@@ -8,6 +8,34 @@ export class WhatsAppService {
 
   private readonly token = process.env.WA_TOKEN ?? '';
 
+  private registrationAttempted = false;
+
+  private async registerPhoneIfNeeded(): Promise<void> {
+    if (this.registrationAttempted || !this.phoneNumberId || !this.token) {
+      return;
+    }
+    this.registrationAttempted = true;
+    const url = `https://graph.facebook.com/v22.0/${this.phoneNumberId}/register`;
+    const payload = {
+      messaging_product: 'whatsapp',
+      pin: '654321',
+    };
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${this.token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      this.log.error(`WhatsApp registration failed: ${text}`);
+    } else {
+      this.log.log('WhatsApp phone number registered');
+    }
+  }
+
   async sendMessage(to: string, body: string): Promise<void> {
     if (!this.phoneNumberId || !this.token) {
       this.log.warn('WhatsApp disabled: missing WA_PHONE_NUMBER_ID or WA_TOKEN');
@@ -31,17 +59,24 @@ export class WhatsAppService {
     if (!res.ok) {
       const text = await res.text();
       this.log.error(`Failed to send: ${text}`);
+      let notRegistered = false;
       try {
         const data = JSON.parse(text);
         const err = data?.error;
         if (err?.code === 133010 || err?.error_subcode === 2593006) {
-          this.log.warn(
-            'WhatsApp account not registered. Call /register API before sending messages.',
-          );
-          return;
+          notRegistered = true;
         }
       } catch {
         // ignore JSON parse failures
+      }
+      if (notRegistered) {
+        const firstAttempt = !this.registrationAttempted;
+        this.log.warn('WhatsApp account not registered. Attempting registration.');
+        await this.registerPhoneIfNeeded();
+        if (firstAttempt) {
+          return this.sendMessage(to, body);
+        }
+        return;
       }
       throw new Error(`WhatsApp API error ${res.status}`);
     }


### PR DESCRIPTION
## Summary
- add a helper to register the WhatsApp number
- retry sending once after registering when unregistered

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68616fd85998832eb5d9baca805460ad