### PR TITLE
Send WhatsApp templates after survey

### DIFF
--- a/backend/src/scheduler/scheduler.controller.ts
+++ b/backend/src/scheduler/scheduler.controller.ts
@@ -16,6 +16,19 @@ export class SchedulerController {
     return { status: 'scheduled' };
   }
 
+  @Post('template')
+  @HttpCode(201)
+  async scheduleTemplate(
+    @Body('time') time: string,
+    @Body('phone') phone: string,
+    @Body('name') name: string,
+    @Body('language') language: string,
+    @Body('components') components?: unknown[],
+  ) {
+    await this.scheduler.scheduleTemplate(phone, time, name, language, components);
+    return { status: 'scheduled' };
+  }
+
   @Post('cancel/:phone')
   @HttpCode(200)
   async cancel(@Param('phone') phone: string) {

--- a/frontend/survey/src/App.jsx
+++ b/frontend/survey/src/App.jsx
@@ -300,17 +300,22 @@ export default function App() {
       }
       document.getElementById('successMessage').style.display = 'block';
 
-      await fetch('/api/schedule', {
+      await fetch('/api/schedule/template', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           time: new Date(Date.now() + 1 * 60 * 1000).toISOString(),
           phone,
-          content:
-            `Olá ${name}, obrigado por dedicar seu tempo para preencher a pesquisa de avaliação de imóvel. Para ajudar a refinar sua estimativa, gostaria de fazer algumas perguntas rápidas.
-
-Você poderia me contar um pouco sobre quaisquer atualizações ou melhorias recentes que tenha feito na propriedade? Coisas como reforma da cozinha, telhado novo ou piso atualizado podem influenciar bastante o valor.
-`,
+          name: 'opt_in_pt',
+          language: 'pt_BR',
+          components: [
+            {
+              type: 'HEADER',
+              parameters: [
+                { type: 'TEXT', parameter_name: 'name', text: name },
+              ],
+            },
+          ],
         }),
       });
       // await fetch('/api/message', {


### PR DESCRIPTION
## Summary
- add WhatsApp template sending logic
- allow Messenger to send WhatsApp templates
- support scheduling template sends from the API
- process scheduled template messages in the cron service
- schedule template instead of text in the survey frontend

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686189e27030832e8283ea326e20208e