### PR TITLE
Fix OAuth redirect domain

### DIFF
--- a/backend/src/calendar/calendar.controller.ts
+++ b/backend/src/calendar/calendar.controller.ts
@@ -26,7 +26,7 @@ export class CalendarController {
   ) {
     const realtorId = state;
     await this.calendar.handleOAuthCallback(code, realtorId);
-    return res.redirect('/console');
+    return res.redirect('https://br.myrealvaluation.com/console/');
   }
 
   @Get('oauth/:realtorId')


### PR DESCRIPTION
## Summary
- ensure calendar OAuth redirect goes to `br.myrealvaluation.com/console`

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6861ab843070832e908dee183c97ff5f