### PR TITLE
Enable Redis persistence via Docker volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ All services can be started with Docker:
 docker-compose up --build
 ```
 This brings up the API, both front ends and Redis using the same ports as above.
+Redis uses a named Docker volume (`redis-data`) so conversation history
+persists across container restarts.
 
 ### Deployment (host Nginx)
 Ubuntu’s built-in Nginx now owns ports **80/443**. All Docker services expose

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     image: redis:7
     ports:
       - "6379:6379"
+    volumes:
+      - redis-data:/data
 
   # ── backend ──────────────────────────────────────────────────
   api:
@@ -83,3 +85,6 @@ services:
       - api
     ports:
       - "4176:80"
+
+volumes:
+  redis-data:

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -3,7 +3,8 @@
 Before publishing the Lead Management System, verify that the following features work as expected:
 
 ## Backend
-- [ ] Database migrations run successfully and data persists across restarts.<br>-_Redis dose not persits._
+- [ ] Database migrations run successfully and data persists across restarts.
+- [ ] Redis data persists thanks to the `redis-data` volume.
 - [ ] Background jobs and queues (BullMQ) process tasks correctly.
 - [ ] Environment variables are loaded and validated.
 - [ ] Make this github is private.


### PR DESCRIPTION
## Summary
- store Redis data in a named volume
- document Redis persistence in README
- update release checklist with Redis persistence step

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6861bcbfeb30832eadf15eaa05ee9d8d