### PR TITLE
Adjust reminder delay

### DIFF
--- a/frontend/survey/src/App.jsx
+++ b/frontend/survey/src/App.jsx
@@ -304,7 +304,7 @@ export default function App() {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          time: new Date(Date.now() + 1 * 60 * 1000).toISOString(),
+          time: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
           phone,
           name: 'opt_in_pt',
           language: 'pt_BR',


### PR DESCRIPTION
## Summary
- delay survey reminder messages by 5 minutes instead of 1

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6861bc7cda28832e9e756003e65d671e